### PR TITLE
Second rules update in v1 branch, update names, update `write_standard_name_table.py` to allow for subsections

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1,7 +1,6 @@
 # CCPP Standard Name Library
 #### Table of Contents
 * [base_names](#base_names)
-* [base_standard_names](#base_standard_names)
 * [dimensions](#dimensions)
 * [constants](#constants)
 * [coordinates](#coordinates)
@@ -146,7 +145,7 @@ These are the base names for specific chemical species
 * `silicate`: Chemical species containing the silicate ion
 * `sulfate`: Chemical species containing the sulfate ion
 * `sulfur_dioxide`: so2
-## base_standard_names
+### base_standard_names
 These names are used as bases for other names, but may
 also be considered standard names on their own. See the
 full list of standard names for further details.

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -41,8 +41,6 @@ more specific standard names.
     * `integer`: units = 1
 * `coefficient`: coefficient
     * `real`: units = 1
-* `coefficient`: coefficient
-    * `real`: units = 1
 * `data_mask`: data_mask
     * `real`: units = 1
 * `density`: density

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1,5 +1,6 @@
 # CCPP Standard Name Library
 #### Table of Contents
+* [base_names](#base_names)
 * [dimensions](#dimensions)
 * [constants](#constants)
 * [coordinates](#coordinates)
@@ -22,6 +23,100 @@
 * [GFS_typedefs_GFS_grid_type](#gfs_typedefs_gfs_grid_type)
 * [GFS_typedefs_GFS_stateout_type](#gfs_typedefs_gfs_stateout_type)
 
+## base_names
+Base names are the 'elemental' quantities from which
+the more complex standard names are constructed.
+Base names can roughly be broken down into three categories:
+### generic_names
+The following names are too general to be chosen as
+standard names, but they can serve as base names for
+more specific standard names.
+* `amount`: amount
+    * `real`: units = kg m-2
+* `area`: area
+    * `real`: units = m2
+* `area_fraction`: area_fraction
+    * `real`: units = 1
+* `binary_mask`: binary_mask
+    * `integer`: units = 1
+* `coefficient`: coefficient
+    * `real`: units = 1
+* `coefficient`: coefficient
+    * `real`: units = 1
+* `data_mask`: data_mask
+    * `real`: units = 1
+* `density`: density
+    * `real`: units = kg m-3
+* `energy`: energy
+    * `real`: units = J
+* `energy_content`: energy_content
+    * `real`: units = J m-2
+* `energy_density`: energy_density
+    * `real`: units = J m-3
+* `frequency`: frequency
+    * `real`: units = s-1
+* `heat_flux`: heat_flux
+    * `real`: units = W m-2
+* `heat_transport`: heat_transport
+    * `real`: units = W
+* `mass`: mass
+    * `real`: units = kg
+* `mass_flux`: mass_flux
+    * `real`: units = kg m-2 s-1
+* `mass_fraction`: mass_fraction
+    * `real`: units = 1
+* `mixing_ratio`: mixing_ratio
+    * `real`: units = kg kg-1
+* `mass_transport`: mass_transport
+    * `real`: units = kg s-1
+* `mole_fraction`: mole_fraction
+    * `real`: units = 1
+* `mole_flux`: mole_flux
+    * `real`: units = mol m-2 s-1
+* `momentum_flux`: momentum_flux
+    * `real`: units = Pa
+* `partial_pressure`: partial_pressure
+    * `real`: units = Pa
+* `period`: period
+    * `real`: units = s
+* `power`: power
+    * `real`: units = W
+* `pressure`: pressure
+    * `real`: units = Pa
+* `probability`: probability
+    * `real`: units = 1
+* `radiative_flux`: radiative_flux
+    * `real`: units = W m-2
+* `radius`: radius
+    * `real`: units = m
+* `specific_eddy_kinetic_energy`: specific_eddy_kinetic_energy
+    * `real`: units = m2 s-2
+* `speed`: speed
+    * `real`: units = m s-1
+* `stress`: stress
+    * `real`: units = Pa
+* `streamfunction`: streamfunction
+    * `real`: units = m2 s-1
+* `temperature`: temperature
+    * `real`: units = K
+* `thickness`: thickness
+    * `real`: units = m
+* `velocity`: velocity
+    * `real`: units = m s-1
+* `velocity_potential`: velocity_potential
+    * `real`: units = m2 s-1
+* `volume`: volume
+    * `real`: units = m3
+* `volume_flux`: volume_flux
+    * `real`: units = m s-1
+* `volume_fraction`: volume_fraction
+    * `real`: units = 1
+* `volume_mixing_ratio`: volume_mixing_ratio
+    * `real`: units = mol mol-1
+* `volume_transport`: volume_transport
+    * `real`: units = m3 s-1
+* `vorticity`: vorticity
+    * `real`: units = s-1
 ## dimensions
 Dimension standard names may come in sets of six related standard names for each dimension:
 ```

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -154,7 +154,6 @@ full list of standard names for further details.
 * `air_pressure`: air_pressure
 * `air_pressure_thickness`: air_pressure_thickness
 * `air_temperature`: air_temperature
-* `air_temperature/water_vapor`: air_temperature/water_vapor
 * `albedo`: albedo
 * `atmosphere_heat_diffusivity`: atmosphere_heat_diffusivity
 * `cloud_area_fraction`: cloud_area_fraction
@@ -163,14 +162,14 @@ full list of standard names for further details.
 * `cloud_liquid_water`: cloud_liquid_water
 * `date`: date
 * `density`: density
-* `diffuse_nir_albedo`: diffuse_nir_albedo
-* `diffuse_nir_shortwave_flux`: diffuse_nir_shortwave_flux
+* `diffuse_nir_albedo`: diffuse near-infrared albedo
+* `diffuse_nir_shortwave_flux`: diffuse near-infrared shortwave flux
 * `diffuse_shortwave_albedo`: diffuse_shortwave_albedo
-* `diffuse_uv_and_vis_shortwave_flux`: diffuse_uv_and_vis_shortwave_flux
+* `diffuse_uv_and_vis_shortwave_flux`: diffuse ultraviolet and visible shortwave flux
 * `diffuse_visible_albedo`: diffuse_visible_albedo
-* `direct_nir_albedo`: direct_nir_albedo
-* `direct_nir_shortwave_flux`: direct_nir_shortwave_flux
-* `direct_uv_and_vis_shortwave_flux`: direct_uv_and_vis_shortwave_flux
+* `direct_nir_albedo`: direct near-infrared albedo
+* `direct_nir_shortwave_flux`: direct near-infrared shortwave flux
+* `direct_uv_and_vis_shortwave_flux`: direct ultraviolet and visible shortwave flux
 * `direct_visible_albedo`: direct_visible_albedo
 * `divergence`: divergence
 * `dry_air_density`: dry_air_density
@@ -214,14 +213,13 @@ full list of standard names for further details.
 * `temperature_flux`: temperature_flux
 * `time`: time
 * `total_energy`: total_energy
-* `total_water`: total_water
+* `total_water`: All water phases (solid, liquid, gas)
 * `tracer`: tracer
 * `tracers`: tracers
 * `turbulent_kinetic_energy`: turbulent_kinetic_energy
 * `velocity_potential`: velocity_potential
 * `virtual_potential_temperature`: virtual_potential_temperature
 * `virtual_temperature`: virtual_temperature
-* `water`: water
 * `water_vapor`: water_vapor
 * `wind`: wind
 * `wind_speed`: wind_speed
@@ -2067,25 +2065,25 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `convective_cloud_condensate_after_rainout`: Convective cloud condensate after rainout
     * `real(kind=kind_phys)`: units = kg kg-1
-* `cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling diffuse nir shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling diffuse uv and vis shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling direct nir shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling direct uv and vis shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
 * `cumulative_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling longwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
 * `cumulative_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling diffuse nir shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling diffuse uv and vis shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling direct nir shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling direct uv and vis shortwave flux at surface for coupling multiplied by timestep
+* `cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
     * `real(kind=kind_phys)`: units = J m-2
 * `cumulative_net_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling longwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
@@ -2107,25 +2105,25 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `air_pressure_at_surface_for_coupling`: Air pressure at surface for coupling
     * `real(kind=kind_phys)`: units = Pa
-* `downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: Downwelling diffuse nir shortwave flux at surface for coupling
+* `downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: downwelling diffuse near-infrared shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Downwelling diffuse uv and vis shortwave flux at surface for coupling
+* `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: Downwelling direct nir shortwave flux at surface for coupling
+* `downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: downwelling direct near-infrared shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Downwelling direct uv and vis shortwave flux at surface for coupling
+* `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
 * `downwelling_longwave_flux_at_surface_for_coupling`: Downwelling longwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
 * `downwelling_shortwave_flux_at_surface_for_coupling`: Downwelling shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: Net downwelling diffuse nir shortwave flux at surface for coupling
+* `net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: net downwelling diffuse near-infrared shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Net downwelling diffuse uv and vis shortwave flux at surface for coupling
+* `net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: Net downwelling direct nir shortwave flux at surface for coupling
+* `net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: net downwelling direct near-infrared shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Net downwelling direct uv and vis shortwave flux at surface for coupling
+* `net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling
     * `real(kind=kind_phys)`: units = W m-2
 * `net_downwelling_longwave_flux_at_surface_for_coupling`: Net downwelling longwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
@@ -2167,13 +2165,13 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = W m-2
 * `area_type_from_coupled_process`: Area type from coupled process
     * `real(kind=kind_phys)`: units = 1
-* `downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling diffuse nir shortwave flux at surface on radiation timestep
+* `downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: downwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling diffuse uv and vis shortwave flux at surface on radiation timestep
+* `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: downwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling direct nir shortwave flux at surface on radiation timestep
+* `downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: downwelling direct near-infrared shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling direct uv and vis shortwave flux at surface on radiation timestep
+* `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: downwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
 * `downwelling_longwave_flux_at_surface_on_radiation_timestep`: Downwelling longwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
@@ -2191,13 +2189,13 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = W m-2
 * `upward_sensible_heat_flux_at_surface_from_coupled_process`: Upward sensible heat flux at surface from coupled process
     * `real(kind=kind_phys)`: units = W m-2
-* `upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling diffuse nir shortwave flux at surface on radiation timestep
+* `upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: upwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling diffuse uv and vis shortwave flux at surface on radiation timestep
+* `upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: upwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling direct nir shortwave flux at surface on radiation timestep
+* `upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: upwelling direct near-infrared shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling direct uv and vis shortwave flux at surface on radiation timestep
+* `upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: upwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
 * `upwelling_longwave_flux_at_surface_from_coupled_process`: Upwelling longwave flux at surface from coupled process
     * `real(kind=kind_phys)`: units = W m-2

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1643,7 +1643,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m
 * `max_vegetation_area_fraction`: Max vegetation area fraction
     * `real(kind=kind_phys)`: units = fraction
-* `nir_albedo_strong_cosz`: Nir albedo strong cosz
+* `nir_albedo_strong_cosz`: albedo for near-infrared radiation with strong dependence on cosine of the zenith angle
     * `real(kind=kind_phys)`: units = fraction
 * `nir_albedo_weak_cosz`: Nir albedo weak cosz
     * `real(kind=kind_phys)`: units = fraction
@@ -1703,7 +1703,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m K-1
 * `slow_soil_pool_mass_content_of_carbon`: Slow soil pool mass content of carbon
     * `real(kind=kind_phys)`: units = g m-2
-* `surface_albedo_assuming_deep_snow_on_previous_timestep`: Surface albedo assuming deep snow on previous timestep
+* `albedo_on_previous_timestep_assuming_deep_snow`: Albedo on previous timestep assuming deep snow
     * `real(kind=kind_phys)`: units = fraction
 * `lwe_thickness_of_ice_in_surface_snow`: Lwe thickness of ice in surface snow
     * `real(kind=kind_phys)`: units = mm
@@ -1747,25 +1747,25 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K
 * `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
     * `real(kind=kind_phys)`: units = m
-* `surface_albedo_diffuse_nir_over_ice`: Surface albedo diffuse nir over ice
+* `diffuse_nir_albedo_of_ice`: ice surface albedo for diffuse near-infrared radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_albedo_diffuse_nir_over_land`: Surface albedo diffuse nir over land
+* `diffuse_nir_albedo_of_land`: land surface albedo for diffuse near-infrared radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_albedo_diffuse_visible_over_ice`: Surface albedo diffuse visible over ice
+* `diffuse_visible_albedo_of_ice`: ice surface albedo for diffuse visible radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_albedo_diffuse_visible_over_land`: Surface albedo diffuse visible over land
+* `diffuse_visible_albedo_of_land`: land surface albedo for diffuse visible radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_albedo_direct_nir_over_ice`: Surface albedo direct nir over ice
+* `direct_nir_albedo_of_ice`: ice surface albedo for direct near-infrared radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_albedo_direct_nir_over_land`: Surface albedo direct nir over land
+* `direct_nir_albedo_of_land`: land surface albedo for direct near-infrared radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_albedo_direct_visible_over_ice`: Surface albedo direct visible over ice
+* `direct_visible_albedo_of_ice`: ice surface albedo for direct visible radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_albedo_direct_visible_over_land`: Surface albedo direct visible over land
+* `direct_visible_albedo_of_land`: land surface albedo for direct visible radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_diffused_shortwave_albedo_over_ice`: Surface diffused shortwave albedo over ice
+* `diffuse_shortwave_albedo_of_ice`: ice surface albedo for diffuse shortwave radiation
     * `real(kind=kind_phys)`: units = fraction
-* `surface_diffused_shortwave_albedo_over_land`: Surface diffused shortwave albedo over land
+* `diffuse_shortwave_albedo_of_land`: land surface albedo for diffuse shortwave radiation
     * `real(kind=kind_phys)`: units = fraction
 * `surface_drag_coefficient_for_heat_and_moisture_for_noahmp`: Surface drag coefficient for heat and moisture for noahmp
     * `real(kind=kind_phys)`: units = 1
@@ -1807,7 +1807,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `surface_snow_area_fraction_over_land`: Surface snow area fraction over land
     * `real(kind=kind_phys)`: units = fraction
-* `surface_snow_free_albedo_over_land`: Surface snow free albedo over land
+* `albedo_of_land_assuming_no_snow_cover`: surface snow-free albedo over land
     * `real(kind=kind_phys)`: units = fraction
 * `lwe_surface_snow`: Lwe surface snow
     * `real(kind=kind_phys)`: units = mm
@@ -1978,9 +1978,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = W m-2
 * `surface_net_downwelling_shortwave_flux_on_radiation_timestep`: Surface net downwelling shortwave flux on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_nir_albedo_diffuse_rad_for_coupling`: Surface nir albedo diffuse rad for coupling
+* `diffuse_nir_albedo_for_coupling`: surface albedo for diffuse near-infrared radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
-* `surface_nir_albedo_direct_rad_for_coupling`: Surface nir albedo direct rad for coupling
+* `direct_nir_albedo_for_coupling`: surface albedo for direct near-infrared radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
 * `lwe_surface_snow_from_coupled_process`: Lwe surface snow from coupled process
     * `real(kind=kind_phys)`: units = m
@@ -2000,9 +2000,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = W m-2
 * `surface_upwelling_longwave_flux_on_radiation_timestep`: Surface upwelling longwave flux on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_vis_albedo_diffuse_rad_for_coupling`: Surface vis albedo diffuse rad for coupling
+* `diffuse_visible_albedo_for_coupling`: surface albedo for diffuse visible radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
-* `surface_vis_albedo_direct_rad_for_coupling`: Surface vis albedo direct rad for coupling
+* `direct_visible_albedo_for_coupling`: surface albedo for direct visible radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
 * `surface_x_momentum_flux_from_coupled_process`: Surface x momentum flux from coupled process
     * `real(kind=kind_phys)`: units = Pa
@@ -2091,7 +2091,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `surface_lw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep`: Surface lw fluxes assuming total and clear sky on radiation timestep
     * `sfcflw_type(kind=)`: units = W m-2
-* `surface_albedo_for_diffused_shortwave_on_radiation_timestep`: Surface albedo for diffused shortwave on radiation timestep
+* `diffuse_shortwave_albedo_on_radiation_timestep`: surface albedo for diffuse shortwave radiation on the timestep for radiation physics
     * `real(kind=kind_phys)`: units = fraction
 * `surface_longwave_emissivity`: Surface longwave emissivity
     * `real(kind=kind_phys)`: units = fraction

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1046,9 +1046,9 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of snow mixing ratio wrt moist air in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of specific humidity on previous timestep in xyz dimensioned restart array
+* `index_of_water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of specific humidity (qv) on previous timestep in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_specific_humidity_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of specific humidity two timesteps back in xyz dimensioned restart array
+* `index_of_water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of specific humidity (qv) two timesteps back in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `control_for_stochastic_land_surface_perturbation`: Control for stochastic land surface perturbation
     * `integer(kind=)`: units = 1
@@ -1062,7 +1062,7 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array`: Index of mass number concentration of hygroscopic aerosols in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_specific_humidity_in_tracer_concentration_array`: Index of specific humidity in tracer concentration array
+* `index_of_water_vapor_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of specific humidity (qv) in tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array`: Index of atmosphere heat diffusivity in xyz dimensioned restart array
     * `integer(kind=)`: units = index
@@ -1407,7 +1407,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = J s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols`: Process split cumulative tendency of mass number concentration of hygroscopic aerosols
     * `real(kind=kind_phys)`: units = kg-1 s-1
-* `process_split_cumulative_tendency_of_specific_humidity`: Process split cumulative tendency of specific humidity
+* `process_split_cumulative_tendency_of_water_vapor_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of specific humidity (qv)
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_x_wind`: Process split cumulative tendency of x wind
     * `real(kind=kind_phys)`: units = m s-2
@@ -1458,7 +1458,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg-1
 * `upward_virtual_potential_temperature_flux`: Upward virtual potential temperature flux
     * `real(kind=kind_phys)`: units = K m s-1
-* `upward_specific_humidity_flux_at_surface_for_mellor_yamada_janjic_surface_layer_scheme`: Upward specific humidity flux at surface for mellor yamada janjic surface layer scheme
+* `upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_mellor_yamada_janjic_surface_layer_scheme`: Upward flux of specific humidity (qv) at surface for MYJ surface layer scheme
     * `real(kind=kind_phys)`: units = m s-1 kg kg-1
 * `cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative max vertical index at cloud base between sw radiation calls
     * `real(kind=kind_phys)`: units = 1
@@ -1468,9 +1468,9 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `turbulent_mixing_length`: Turbulent mixing length
     * `real(kind=kind_phys)`: units = m
-* `specific_humidity_on_previous_timestep`: Specific humidity on previous timestep
+* `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep`: Specific humidity (qv) on previous timestep
     * `real(kind=kind_phys)`: units = kg kg-1
-* `tendency_of_specific_humidity_due_to_nonphysics`: Tendency of specific humidity due to nonphysics
+* `tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_nonphysics`: Tendency of specific humidity (qv) due to nonphysics
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `momentum_exchange_coefficient_for_myj_schemes`: Momentum exchange coefficient for myj schemes
     * `real(kind=kind_phys)`: units = m s-1
@@ -1478,7 +1478,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = various
 * `air_potential_temperature_at_top_of_viscous_sublayer`: Air potential temperature at top of viscous sublayer
     * `real(kind=kind_phys)`: units = K
-* `variance_of_specific_humidity`: Variance of specific humidity
+* `variance_of_water_vapor_mixing_ratio_wrt_moist_air`: Variance of specific humidity (qv)
     * `real(kind=kind_phys)`: units = kg2 kg-2
 * `random_number`: Random number
     * `real(kind=kind_phys)`: units = 1
@@ -1488,7 +1488,7 @@ Variables related to the compute environment
     * `integer(kind=)`: units = 1
 * `cumulative_min_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative min vertical index at cloud base between sw radiation calls
     * `real(kind=kind_phys)`: units = 1
-* `specific_humidity_at_top_of_viscous_sublayer`: Specific humidity at top of viscous sublayer
+* `water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Water vapor mixing ratio wrt moist air at top of viscous sublayer
     * `real(kind=kind_phys)`: units = kg kg-1
 * `stability_function_for_heat`: Stability function for heat
     * `real(kind=kind_phys)`: units = 1
@@ -1506,11 +1506,11 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = Pa
 * `control_for_surface_layer_evaporation`: Control for surface layer evaporation
     * `real(kind=kind_phys)`: units = 1
-* `surface_specific_humidity_for_myj_schemes`: Surface specific humidity for myj schemes
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_schemes`: Surface specific humidity (qv) for MYJ schemes
     * `real(kind=kind_phys)`: units = kg kg-1
 * `enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convection`: Enhancement to wind speed at surface adjacent layer due to convection
     * `real(kind=kind_phys)`: units = m s-1
-* `covariance_of_air_temperature_and_specific_humidity`: Covariance of air temperature and specific humidity
+* `covariance_of_air_temperature_and_water_vapor_mixing_ratio_wrt_moist_air`: Covariance of air temperature and specific humidity (qv)
     * `real(kind=kind_phys)`: units = K kg kg-1
 * `variance_of_air_temperature`: Variance of air temperature
     * `real(kind=kind_phys)`: units = K2
@@ -1530,15 +1530,15 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m s-1
 * `y_wind_at_top_of_viscous_sublayer`: Y wind at top of viscous sublayer
     * `real(kind=kind_phys)`: units = m s-1
-* `specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array`: Specific humidity on previous timestep in xyz dimensioned restart array
+* `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Specific humidity (qv) on previous timestep in XYZ-dimensioned restart array
     * `real(kind=kind_phys)`: units = kg kg-1
-* `specific_humidity_two_timesteps_back`: Specific humidity two timesteps back
+* `water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back`: Specific humidity (qv) two timesteps back
     * `real(kind=kind_phys)`: units = kg kg-1
 * `weight_for_momentum_at_top_of_viscous_sublayer`: Weight for momentum at top of viscous sublayer
     * `real(kind=kind_phys)`: units = 1
 * `weight_for_potential_temperature_at_top_of_viscous_sublayer`: Weight for potential temperature at top of viscous sublayer
     * `real(kind=kind_phys)`: units = 1
-* `weight_for_specific_humidity_at_top_of_viscous_sublayer`: Weight for specific humidity at top of viscous sublayer
+* `weight_for_water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Weight for specific humidity (qv) at the top of the viscous sublayer
     * `real(kind=kind_phys)`: units = 1
 ## GFS_typedefs_GFS_sfcprop_type
 * `wet_canopy_area_fraction`: Wet canopy area fraction
@@ -1613,7 +1613,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `temperature_in_ice_layer`: Temperature in ice layer
     * `real(kind=kind_phys)`: units = K
-* `upward_specific_humidity_flux_at_surface`: Upward specific humidity flux at surface
+* `upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Upward flux of water vapor mixing ratio wrt moist air at surface
     * `real(kind=kind_phys)`: units = kg kg-1 m s-1
 * `upward_temperature_flux_at_surface`: Upward temperature flux at surface
     * `real(kind=kind_phys)`: units = K m s-1
@@ -1727,11 +1727,11 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K
 * `volumetric_soil_moisture_between_soil_bottom_and_water_table`: Volumetric soil moisture between soil bottom and water table
     * `real(kind=kind_phys)`: units = m3 m-3
-* `water_vapor_mixing_ratio_wrt_moist_air_at_2m`: mixing ratio of the mass of water vapor to the mass of moist air, at two meters above surface
+* `water_vapor_mixing_ratio_wrt_moist_air_at_2m`: Specific humidity (qv) at two meters above surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m`: mixing ratio of the mass of water vapor to the mass of moist air and hydrometeors, at two meters above surface
     * `real(kind=kind_phys)`: units = kg kg-1
-* `specified_upward_specific_humidity_flux_at_surface`: Specified upward specific humidity flux at surface
+* `specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specified upward specific humidity (qv) flux at surface
     * `real(kind=kind_phys)`: units = kg kg-1 m s-1
 * `specified_upward_temperature_flux_at_surface`: Specified upward temperature flux at surface
     * `real(kind=kind_phys)`: units = K m s-1
@@ -1811,7 +1811,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `lwe_surface_snow`: Lwe surface snow
     * `real(kind=kind_phys)`: units = mm
-* `surface_specific_humidity`: Surface specific humidity
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specific humidity (qv) at surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `ratio_of_height_to_monin_obukhov_length`: Ratio of height to monin obukhov length
     * `real(kind=kind_phys)`: units = 1
@@ -1900,7 +1900,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `atmosphere_heat_diffusivity_for_chemistry_coupling`: Atmosphere heat diffusivity for chemistry coupling
     * `real(kind=kind_phys)`: units = m2 s-1
-* `specific_humidity_at_2m_for_coupling`: Specific humidity at 2m for coupling
+* `water_vapor_mixing_ratio_wrt_moist_air_at_2m_for_coupling`: Specific humidity (qv) at 2 meters above surface used for coupling
     * `real(kind=kind_phys)`: units = kg kg-1
 * `air_pressure_at_surface_for_coupling`: Air pressure at surface for coupling
     * `real(kind=kind_phys)`: units = Pa
@@ -1942,7 +1942,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = Pa
 * `temperature_at_2m_for_coupling`: Temperature at 2m for coupling
     * `real(kind=kind_phys)`: units = K
-* `tendency_of_specific_humidity_due_to_moist_convection_for_coupling`: Tendency of specific humidity due to moist convection for coupling
+* `tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_moist_convection_for_coupling`: Tendency of water vapor mixing ratio wrt moist air due to moist convection for coupling
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `x_wind_at_10m_for_coupling`: X wind at 10m for coupling
     * `real(kind=kind_phys)`: units = m s-1
@@ -2071,7 +2071,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = J
 * `mass_number_concentration_of_hygroscopic_aerosols`: Mass number concentration of hygroscopic aerosols
     * `real(kind=kind_phys)`: units = kg-1
-* `specific_humidity_at_surface_adjacent_layer`: Specific humidity at surface adjacent layer
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer`: Specific humidity (qv) at surface-adjacent layer
     * `real(kind=kind_phys)`: units = kg kg-1
 * `x_wind_at_surface_adjacent_layer`: X wind at surface adjacent layer
     * `real(kind=kind_phys)`: units = m s-1
@@ -2197,9 +2197,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_hygroscopic_aerosols_of_new_state`: Mass number concentration of hygroscopic aerosols of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `specific_humidity_of_new_state_at_surface_adjacent_layer`: Specific humidity of new state at surface adjacent layer
+* `water_vapor_mixing_ratio_wrt_moist_air_of_new_state_at_surface_adjacent_layer`: Specific humidity (qv) of new state at surface-adjacent layer
     * `real(kind=kind_phys)`: units = kg kg-1
-* `specific_humidity_of_new_state`: Specific humidity of new state
+* `water_vapor_mixing_ratio_wrt_moist_air_of_new_state`: Specific humidity (qv) of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `x_wind_of_new_state_at_surface_adjacent_layer`: X wind of new state at surface adjacent layer
     * `real(kind=kind_phys)`: units = m s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -164,11 +164,11 @@ full list of standard names for further details.
 * `diffuse_nir_shortwave_flux`: diffuse near-infrared shortwave flux
 * `diffuse_shortwave_albedo`: diffuse_shortwave_albedo
 * `diffuse_uv_and_vis_shortwave_flux`: diffuse ultraviolet and visible shortwave flux
-* `diffuse_visible_albedo`: diffuse_visible_albedo
+* `diffuse_vis_albedo`: diffuse visible albedo
 * `direct_nir_albedo`: direct near-infrared albedo
 * `direct_nir_shortwave_flux`: direct near-infrared shortwave flux
 * `direct_uv_and_vis_shortwave_flux`: direct ultraviolet and visible shortwave flux
-* `direct_visible_albedo`: direct_visible_albedo
+* `direct_vis_albedo`: direct visible albedo
 * `divergence`: divergence
 * `dry_air_density`: dry_air_density
 * `dry_air_enthalpy`: dry_air_enthalpy
@@ -1950,17 +1950,17 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `diffuse_nir_albedo_of_land`: land surface albedo for diffuse near-infrared radiation
     * `real(kind=kind_phys)`: units = fraction
-* `diffuse_visible_albedo_of_ice`: ice surface albedo for diffuse visible radiation
+* `diffuse_vis_albedo_of_ice`: ice surface albedo for diffuse visible radiation
     * `real(kind=kind_phys)`: units = fraction
-* `diffuse_visible_albedo_of_land`: land surface albedo for diffuse visible radiation
+* `diffuse_vis_albedo_of_land`: land surface albedo for diffuse visible radiation
     * `real(kind=kind_phys)`: units = fraction
 * `direct_nir_albedo_of_ice`: ice surface albedo for direct near-infrared radiation
     * `real(kind=kind_phys)`: units = fraction
 * `direct_nir_albedo_of_land`: land surface albedo for direct near-infrared radiation
     * `real(kind=kind_phys)`: units = fraction
-* `direct_visible_albedo_of_ice`: ice surface albedo for direct visible radiation
+* `direct_vis_albedo_of_ice`: ice surface albedo for direct visible radiation
     * `real(kind=kind_phys)`: units = fraction
-* `direct_visible_albedo_of_land`: land surface albedo for direct visible radiation
+* `direct_vis_albedo_of_land`: land surface albedo for direct visible radiation
     * `real(kind=kind_phys)`: units = fraction
 * `diffuse_shortwave_albedo_of_ice`: ice surface albedo for diffuse shortwave radiation
     * `real(kind=kind_phys)`: units = fraction
@@ -2199,9 +2199,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = W m-2
 * `upwelling_longwave_flux_at_surface_on_radiation_timestep`: Upwelling longwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `diffuse_visible_albedo_for_coupling`: surface albedo for diffuse visible radiation for coupling
+* `diffuse_vis_albedo_for_coupling`: surface albedo for diffuse visible radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
-* `direct_visible_albedo_for_coupling`: surface albedo for direct visible radiation for coupling
+* `direct_vis_albedo_for_coupling`: surface albedo for direct visible radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
 * `x_momentum_flux_at_surface_from_coupled_process`: X momentum flux at surface from coupled process
     * `real(kind=kind_phys)`: units = Pa

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -115,7 +115,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `surface_pressure_of_dry_air`: Surface pressure of dry air
     * `real(kind=kind_phys)`: units = Pa
-* `surface_geopotential`: Surface geopotential
+* `geopotential_at_surface`: Geopotential at surface
     * `real(kind=kind_phys)`: units = m2 s-2
 * `air_temperature`: Air temperature
     * `real(kind=kind_phys)`: units = K
@@ -165,7 +165,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `ln_air_pressure_of_dry_air`: Ln air pressure of dry air
     * `real(kind=kind_phys)`: units = 1
-* `reciprocal_of_exner_function_wrt_surface_air_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
+* `reciprocal_of_exner_function_wrt_air_pressure_at_surface`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: geopotential height w.r.t. sea level
     * `real(kind=kind_phys)`: units = m
@@ -231,15 +231,15 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
-* `air_horizontal_streamfunction`: Scalar function describing the streamlines of the horizontal wind
+* `horizontal_streamfunction_of_air`: Scalar function describing the streamlines of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `air_horizontal_velocity_potential`: Scalar potential of the horizontal wind
+* `horizontal_velocity_potential_of_air`: Scalar potential of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the vector wind field
+* `upward_absolute_vorticity_of_air`: The upward (kth) component of the curl of the vector wind field
     * `real(kind=kind_phys)`: units = s-1
-* `air_horizontal_divergence`: The (horizontal) divergence of the 2-D vector wind field
+* `horizontal_divergence_of_air`: The (horizontal) divergence of the 2-D vector wind field
     * `real(kind=kind_phys)`: units = s-1
-* `surface_upward_heat_flux_in_air`: Surface upward heat flux in air
+* `upward_heat_flux_in_air_at_surface`: Upward heat flux in air at surface
     * `real(kind=kind_phys)`: units = W m-2
 * `cumulative_boundary_flux_of_total_energy`: Cumulative boundary flux of total energy
     * `real(kind=kind_phys)`: units = W m-2
@@ -251,7 +251,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = Pa
 * `reference_pressure_in_atmosphere_layer`: reference pressure in atmosphere layer
     * `real(kind=kind_phys)`: units = Pa
-* `reference_air_pressure_normalized_by_surface_air_pressure`: reference pressure normalized by surface pressure
+* `reference_air_pressure_normalized_by_air_pressure_at_surface`: reference pressure normalized by surface pressure
     * `real(kind=kind_phys)`: units = 1
 * `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
     * `real(kind=kind_phys)`: units = 1
@@ -298,7 +298,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = frac
 * `mass_content_of_water_in_top_soil_layer`: content per unit area of water in top layer of soil
     * `real(kind=kind_phys)`: units = kg m-2
-* `surface_snow_density`: Surface snow density
+* `density_of_snow_at_surface`: Density of snow at surface
     * `real(kind=kind_phys)`: units = kg m-3
 * `urban_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is urban
     * `real(kind=kind_phys)`: units = frac
@@ -1052,9 +1052,9 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `control_for_stochastic_land_surface_perturbation`: Control for stochastic land surface perturbation
     * `integer(kind=)`: units = 1
-* `index_of_surface_air_pressure_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of surface air pressure on previous timestep in xyz dimensioned restart array
+* `index_of_air_pressure_at_surface_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of air pressure at surface on previous timestep in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_surface_air_pressure_two_timesteps_back_in_xyz_dimensioned_tracer_array`: Index of surface air pressure two timesteps back in xyz dimensioned tracer array
+* `index_of_air_pressure_at_surface_two_timesteps_back_in_xyz_dimensioned_tracer_array`: Index of air pressure at surface two timesteps back in xyz dimensioned tracer array
     * `integer(kind=)`: units = index
 * `index_of_enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convectionin_in_xy_dimensioned_restart_array`: Index of enhancement to wind speed at surface adjacent layer due to convectionin in xy dimensioned restart array
     * `integer(kind=)`: units = index
@@ -1458,7 +1458,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg-1
 * `upward_virtual_potential_temperature_flux`: Upward virtual potential temperature flux
     * `real(kind=kind_phys)`: units = K m s-1
-* `surface_upward_specific_humidity_flux_for_mellor_yamada_janjic_surface_layer_scheme`: Surface upward specific humidity flux for mellor yamada janjic surface layer scheme
+* `upward_specific_humidity_flux_at_surface_for_mellor_yamada_janjic_surface_layer_scheme`: Upward specific humidity flux at surface for mellor yamada janjic surface layer scheme
     * `real(kind=kind_phys)`: units = m s-1 kg kg-1
 * `cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative max vertical index at cloud base between sw radiation calls
     * `real(kind=kind_phys)`: units = 1
@@ -1500,9 +1500,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `subgrid_scale_cloud_fraction_from_shoc`: Subgrid scale cloud fraction from shoc
     * `real(kind=kind_phys)`: units = fraction
-* `surface_air_pressure_on_previous_timestep`: Surface air pressure on previous timestep
+* `air_pressure_at_surface_on_previous_timestep`: Air pressure at surface on previous timestep
     * `real(kind=kind_phys)`: units = Pa
-* `surface_air_pressure_two_timesteps_back`: Surface air pressure two timesteps back
+* `air_pressure_at_surface_two_timesteps_back`: Air pressure at surface two timesteps back
     * `real(kind=kind_phys)`: units = Pa
 * `control_for_surface_layer_evaporation`: Control for surface layer evaporation
     * `real(kind=kind_phys)`: units = 1
@@ -1613,9 +1613,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `temperature_in_ice_layer`: Temperature in ice layer
     * `real(kind=kind_phys)`: units = K
-* `surface_upward_specific_humidity_flux`: Surface upward specific humidity flux
+* `upward_specific_humidity_flux_at_surface`: Upward specific humidity flux at surface
     * `real(kind=kind_phys)`: units = kg kg-1 m s-1
-* `surface_upward_temperature_flux`: Surface upward temperature flux
+* `upward_temperature_flux_at_surface`: Upward temperature flux at surface
     * `real(kind=kind_phys)`: units = K m s-1
 * `lake_area_fraction`: Lake area fraction
     * `real(kind=kind_phys)`: units = fraction
@@ -1731,9 +1731,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m`: mixing ratio of the mass of water vapor to the mass of moist air and hydrometeors, at two meters above surface
     * `real(kind=kind_phys)`: units = kg kg-1
-* `specified_surface_upward_specific_humidity_flux`: Specified surface upward specific humidity flux
+* `specified_upward_specific_humidity_flux_at_surface`: Specified upward specific humidity flux at surface
     * `real(kind=kind_phys)`: units = kg kg-1 m s-1
-* `specified_surface_upward_temperature_flux`: Specified surface upward temperature flux
+* `specified_upward_temperature_flux_at_surface`: Specified upward temperature flux at surface
     * `real(kind=kind_phys)`: units = K m s-1
 * `standard_deviation_of_subgrid_orography`: Standard deviation of subgrid orography
     * `real(kind=kind_phys)`: units = m
@@ -1803,9 +1803,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K
 * `surface_skin_temperature_over_land`: Surface skin temperature over land
     * `real(kind=kind_phys)`: units = K
-* `surface_snow_area_fraction_over_ice`: Surface snow area fraction over ice
+* `snow_area_fraction_at_surface_over_ice`: Snow area fraction at surface over ice
     * `real(kind=kind_phys)`: units = fraction
-* `surface_snow_area_fraction_over_land`: Surface snow area fraction over land
+* `snow_area_fraction_at_surface_over_land`: Snow area fraction at surface over land
     * `real(kind=kind_phys)`: units = fraction
 * `albedo_of_land_assuming_no_snow_cover`: surface snow-free albedo over land
     * `real(kind=kind_phys)`: units = fraction
@@ -1902,7 +1902,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m2 s-1
 * `specific_humidity_at_2m_for_coupling`: Specific humidity at 2m for coupling
     * `real(kind=kind_phys)`: units = kg kg-1
-* `surface_air_pressure_for_coupling`: Surface air pressure for coupling
+* `air_pressure_at_surface_for_coupling`: Air pressure at surface for coupling
     * `real(kind=kind_phys)`: units = Pa
 * `surface_downwelling_diffuse_nir_shortwave_flux_for_coupling`: Surface downwelling diffuse nir shortwave flux for coupling
     * `real(kind=kind_phys)`: units = W m-2
@@ -2004,9 +2004,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `direct_visible_albedo_for_coupling`: surface albedo for direct visible radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
-* `surface_x_momentum_flux_from_coupled_process`: Surface x momentum flux from coupled process
+* `x_momentum_flux_at_surface_from_coupled_process`: X momentum flux at surface from coupled process
     * `real(kind=kind_phys)`: units = Pa
-* `surface_y_momentum_flux_from_coupled_process`: Surface y momentum flux from coupled process
+* `y_momentum_flux_at_surface_from_coupled_process`: Y momentum flux at surface from coupled process
     * `real(kind=kind_phys)`: units = Pa
 * `tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer`: Tendency of nonhygroscopic ice nucleating aerosols at surface adjacent layer
     * `real(kind=kind_phys)`: units = kg-1 s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -165,7 +165,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `ln_air_pressure_of_dry_air`: Ln air pressure of dry air
     * `real(kind=kind_phys)`: units = 1
-* `reciprocal_of_dimensionless_exner_function_wrt_surface_air_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
+* `reciprocal_of_exner_function_wrt_surface_air_pressure`: inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)
     * `real(kind=kind_phys)`: units = 1
 * `geopotential_height`: geopotential height w.r.t. sea level
     * `real(kind=kind_phys)`: units = m
@@ -255,7 +255,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
     * `real(kind=kind_phys)`: units = 1
-* `dimensionless_exner_function`: exner function
+* `exner_function`: exner function, (p/p0)^(Rd/cp)
     * `real(kind=kind_phys)`: units = 1
 * `air_potential_temperature`: air potential temperature
     * `real(kind=kind_phys)`: units = K
@@ -836,7 +836,7 @@ Variables related to the compute environment
     * `logical(kind=)`: units = flag
 * `do_read_surface_albedo_for_diffused_shortwave_from_input`: Do read surface albedo for diffused shortwave from input
     * `logical(kind=)`: units = flag
-* `do_limited_surface_roughness_length_over_ocean`: Do limited surface roughness length over ocean
+* `do_limited_roughness_length_over_ocean`: Do limited surface roughness length over ocean
     * `logical(kind=)`: units = flag
 * `do_reference_pressure_theta`: Do reference pressure theta
     * `logical(kind=)`: units = flag
@@ -1545,7 +1545,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `baseline_surface_longwave_emissivity`: Baseline surface longwave emissivity
     * `real(kind=kind_phys)`: units = fraction
-* `baseline_surface_roughness_length`: Baseline surface roughness length
+* `baseline_roughness_length`: Baseline surface roughness length
     * `real(kind=kind_phys)`: units = m
 * `air_temperature_in_canopy`: Air temperature in canopy
     * `real(kind=kind_phys)`: units = K
@@ -1789,15 +1789,15 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `surface_longwave_emissivity_over_land`: Surface longwave emissivity over land
     * `real(kind=kind_phys)`: units = fraction
-* `surface_roughness_length`: Surface roughness length
+* `roughness_length`: surface roughness length
     * `real(kind=kind_phys)`: units = cm
-* `surface_roughness_length_from_wave_model`: Surface roughness length from wave model
+* `roughness_length_from_wave_model`: surface roughness length from wave model
     * `real(kind=kind_phys)`: units = cm
-* `surface_roughness_length_over_ice`: Surface roughness length over ice
+* `roughness_length_over_ice`: surface roughness length over ice
     * `real(kind=kind_phys)`: units = cm
-* `surface_roughness_length_over_land`: Surface roughness length over land
+* `roughness_length_over_land`: surface roughness length over land
     * `real(kind=kind_phys)`: units = cm
-* `surface_roughness_length_over_water`: Surface roughness length over water
+* `roughness_length_over_water`: surface roughness length over water
     * `real(kind=kind_phys)`: units = cm
 * `surface_skin_temperature`: Surface skin temperature
     * `real(kind=kind_phys)`: units = K
@@ -2037,11 +2037,11 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air`: Mass number concentration of cloud liquid water particles in air
     * `real(kind=kind_phys)`: units = kg-1
-* `surface_dimensionless_exner_function`: Surface dimensionless exner function
+* `exner_function_wrt_surface_pressure`: exner function w.r.t. surface pressure, (p/ps)^(Rd/cp)
     * `real(kind=kind_phys)`: units = 1
-* `dimensionless_exner_function_at_surface_adjacent_layer`: Dimensionless exner function at surface adjacent layer
+* `exner_function_at_surface_adjacent_layer`: exner function (p/p0)^(Rd/cp), where p0 is the pressure at the surface adjacent layer
     * `real(kind=kind_phys)`: units = 1
-* `dimensionless_exner_function_at_interfaces`: Dimensionless exner function at interfaces
+* `exner_function_at_interfaces`: exner function (p/p0)^(Rd/cp), where p0 is the pressure at vertical layer interfaces
     * `real(kind=kind_phys)`: units = 1
 * `dissipation_estimate_of_air_temperature_at_model_layers`: Dissipation estimate of air temperature at model layers
     * `real(kind=kind_phys)`: units = K

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -454,7 +454,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = 1
 * `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
     * `real(kind=kind_phys)`: units = 1
-* `exner_function`: exner function, (p/p0)^(Rd/cp)
+* `exner_function`: exner function, (p/p0)^(Rd/cp), where p0 is 1000 hPa
     * `real(kind=kind_phys)`: units = 1
 * `air_potential_temperature`: air potential temperature
     * `real(kind=kind_phys)`: units = K
@@ -2238,9 +2238,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg-1
 * `exner_function_wrt_surface_pressure`: exner function w.r.t. surface pressure, (p/ps)^(Rd/cp)
     * `real(kind=kind_phys)`: units = 1
-* `exner_function_at_surface_adjacent_layer`: exner function (p/p0)^(Rd/cp), where p0 is the pressure at the surface adjacent layer
+* `exner_function_at_surface_adjacent_layer`: exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at the surface adjacent layer
     * `real(kind=kind_phys)`: units = 1
-* `exner_function_at_interfaces`: exner function (p/p0)^(Rd/cp), where p0 is the pressure at vertical layer interfaces
+* `exner_function_at_interfaces`: exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at vertical layer interfaces
     * `real(kind=kind_phys)`: units = 1
 * `dissipation_estimate_of_air_temperature_at_model_layers`: Dissipation estimate of air temperature at model layers
     * `real(kind=kind_phys)`: units = K

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -231,11 +231,11 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
-* `air_horizontal_streamfunction`: Scalar function describing the streamlines of the horizontal wind
+* `air_horizontal_streamfunction`: Scalar function describing the stream lines of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
 * `air_horizontal_velocity_potential`: Scalar potential of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the vector wind field
+* `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the horizontal vector wind field
     * `real(kind=kind_phys)`: units = s-1
 * `air_horizontal_divergence`: The (horizontal) divergence of the 2-D vector wind field
     * `real(kind=kind_phys)`: units = s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1,6 +1,7 @@
 # CCPP Standard Name Library
 #### Table of Contents
 * [base_names](#base_names)
+* [base_standard_names](#base_standard_names)
 * [dimensions](#dimensions)
 * [constants](#constants)
 * [coordinates](#coordinates)
@@ -117,6 +118,114 @@ more specific standard names.
     * `real`: units = m3 s-1
 * `vorticity`: vorticity
     * `real`: units = s-1
+### chemical_species
+These are the base names for specific chemical species
+* `c5h8`: Isoprene
+* `co2`: Carbon dioxide
+* `co`: Carbon monoxide
+* `ccl4`: Tetrachloromethane
+* `cfc11`: Trichlorofluoromethane
+* `cfc12`: Dichlorodifluoromethane
+* `cfc113`: 1,1,2-Trichloro-1,2,2-trifluoroethane
+* `cfc22`: Chlorodifluoromethane
+* `dimethyl_sulfide`: Dimethyl sulfide; DMS
+* `hcho`: Formaldehyde
+* `hydrophilic_black_carbon`: hydrophilic_black_carbon
+* `hydrophobic_black_carbon`: hydrophobic_black_carbon
+* `hydrophilic_organic_carbon`: hydrophilic_organic_carbon
+* `hydrophobic_organic_carbon`: hydrophobic_organic_carbon
+* `methane`: ch4
+* `n2o`: Nitrous Oxide, N₂O
+* `nitrate`: Chemical species containing the nitrate ion
+* `nitrite`: Chemical species containing the nitrite ion
+* `no2`: Nitrogen dioxide
+* `no`: Nitric oxide NO (Nitrogen oxide, Nitrogen monoxide)
+* `oxygen`: Molecular oxygen, O₂
+* `ozone`: Ozone, O₃
+* `phosphate`: Chemical species containing the phosphate ion
+* `silicate`: Chemical species containing the silicate ion
+* `sulfate`: Chemical species containing the sulfate ion
+* `sulfur_dioxide`: so2
+## base_standard_names
+These names are used as bases for other names, but may
+also be considered standard names on their own. See the
+full list of standard names for further details.
+* `absolute_vorticity`: absolute_vorticity
+* `air_potential_temperature`: air_potential_temperature
+* `air_pressure`: air_pressure
+* `air_pressure_thickness`: air_pressure_thickness
+* `air_temperature`: air_temperature
+* `air_temperature/water_vapor`: air_temperature/water_vapor
+* `albedo`: albedo
+* `atmosphere_heat_diffusivity`: atmosphere_heat_diffusivity
+* `cloud_area_fraction`: cloud_area_fraction
+* `cloud_condensate`: cloud_condensate
+* `cloud_ice`: cloud_ice
+* `cloud_liquid_water`: cloud_liquid_water
+* `date`: date
+* `density`: density
+* `diffuse_nir_albedo`: diffuse_nir_albedo
+* `diffuse_nir_shortwave_flux`: diffuse_nir_shortwave_flux
+* `diffuse_shortwave_albedo`: diffuse_shortwave_albedo
+* `diffuse_uv_and_vis_shortwave_flux`: diffuse_uv_and_vis_shortwave_flux
+* `diffuse_visible_albedo`: diffuse_visible_albedo
+* `direct_nir_albedo`: direct_nir_albedo
+* `direct_nir_shortwave_flux`: direct_nir_shortwave_flux
+* `direct_uv_and_vis_shortwave_flux`: direct_uv_and_vis_shortwave_flux
+* `direct_visible_albedo`: direct_visible_albedo
+* `divergence`: divergence
+* `dry_air_density`: dry_air_density
+* `dry_air_enthalpy`: dry_air_enthalpy
+* `exner_function`: exner_function
+* `filename`: filename
+* `forecast_time`: forecast_time
+* `geopotential`: geopotential
+* `geopotential_height`: geopotential_height
+* `graupel`: graupel
+* `gravitational_acceleration`: gravitational_acceleration
+* `hail`: hail
+* `heat_flux`: heat_flux
+* `hygroscopic_aerosols`: hygroscopic_aerosols
+* `ice`: ice
+* `latent_heat_flux`: latent_heat_flux
+* `liquid_water`: liquid_water
+* `longwave_flux`: longwave_flux
+* `momentum_flux`: momentum_flux
+* `nonhygroscopic_ice_nucleating_aerosols`: nonhygroscopic_ice_nucleating_aerosols
+* `ozone`: ozone
+* `pressure`: pressure
+* `rain`: rain
+* `rain_water`: rain_water
+* `random_number`: random_number
+* `random_number_seed`: random_number_seed
+* `reference_pressure`: reference_pressure
+* `relative_humidity`: relative_humidity
+* `roughness_length`: roughness_length
+* `sensible_heat_flux`: sensible_heat_flux
+* `shortwave_flux`: shortwave_flux
+* `snow`: snow
+* `snow_area_fraction`: snow_area_fraction
+* `soil_moisture`: soil_moisture
+* `soil_temperature`: soil_temperature
+* `solar_declination_angle`: solar_declination_angle
+* `solar_zenith_angle`: solar_zenith_angle
+* `streamfunction`: streamfunction
+* `surface_skin_temperature`: surface_skin_temperature
+* `temperature`: temperature
+* `temperature_flux`: temperature_flux
+* `time`: time
+* `total_energy`: total_energy
+* `total_water`: total_water
+* `tracer`: tracer
+* `tracers`: tracers
+* `turbulent_kinetic_energy`: turbulent_kinetic_energy
+* `velocity_potential`: velocity_potential
+* `virtual_potential_temperature`: virtual_potential_temperature
+* `virtual_temperature`: virtual_temperature
+* `water`: water
+* `water_vapor`: water_vapor
+* `wind`: wind
+* `wind_speed`: wind_speed
 ## dimensions
 Dimension standard names may come in sets of six related standard names for each dimension:
 ```
@@ -469,7 +578,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = K-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
     * `real(kind=kind_phys)`: units = mol mol-1
-* `mole_fraction_of_carbon_dioxide_in_air`: Mole fraction of carbon dioxide in air
+* `mole_fraction_of_co2_in_air`: Mole fraction of co2 in air
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_ch4`: Methane volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -231,11 +231,11 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
-* `air_horizontal_streamfunction`: Scalar function describing the stream lines of the horizontal wind
+* `air_horizontal_streamfunction`: Scalar function describing the streamlines of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
 * `air_horizontal_velocity_potential`: Scalar potential of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the horizontal vector wind field
+* `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the vector wind field
     * `real(kind=kind_phys)`: units = s-1
 * `air_horizontal_divergence`: The (horizontal) divergence of the 2-D vector wind field
     * `real(kind=kind_phys)`: units = s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -364,9 +364,9 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = kg kg-1
 * `total_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: ratio of the mass of water to the mass of dry air at all interfaces excluding surface
     * `real(kind=kind_phys)`: units = kg kg-1
-* `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation`: saturated water vapor mixing ratio with respect to moist air and condensed water
+* `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation`: saturated water vapor mass mixing ratio with respect to moist air and condensed water
     * `real(kind=kind_phys)`: units = kg kg-1
-* `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces_assuming_saturation`: saturated water vapor mixing ratio with respect to moist air and condensed water at all interfaces excluding surface
+* `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces_assuming_saturation`: saturated water vapor mass mixing ratio with respect to moist air and condensed water at all interfaces excluding surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature`: log derivative of the water vapor partial pressure at saturation with respect to air temperature
     * `real(kind=kind_phys)`: units = K-1
@@ -1006,19 +1006,19 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `index_of_convective_cloud_area_fraction_in_xyz_dimensioned_restart_array`: Index of convective cloud area fraction in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_convective_cloud_condensate_mixing_ratio_wrt_moist_air_in_xyz_dimensioned_restart_array`: Index of convective cloud condensate mixing ratio wrt moist air in xyz dimensioned restart array
+* `index_of_convective_cloud_condensate_mixing_ratio_wrt_moist_air_in_xyz_dimensioned_restart_array`: Index of convective cloud condensate mass mixing ratio with respect to moist air in the XYZ-dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_horizontal_gridpoint_for_debug_output`: Index of horizontal gridpoint for debug output
     * `integer(kind=)`: units = index
 * `index_of_first_chemical_tracer_in_tracer_concentration_array`: Index of first chemical tracer in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_graupel_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of graupel mixing ratio wrt moist air in tracer concentration array
+* `index_of_graupel_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of graupel mass mixing ratio with respect to moist air in the tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_graupel_effective_radius_in_xyz_dimensioned_restart_array`: Index of graupel effective radius in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array`: Index of mass number concentration of graupel in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_cloud_ice_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of cloud ice mixing ratio wrt moist air in tracer concentration array
+* `index_of_cloud_ice_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of cloud ice mass mixing ratio with respect to moist air in the tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array`: Index of mass number concentration of cloud ice in tracer concentration array
     * `integer(kind=)`: units = index
@@ -1026,29 +1026,29 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array`: Index of mass number concentration of nonhygroscopic ice nucleating aerosols in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of cloud liquid water mixing ratio wrt moist air in tracer concentration array
+* `index_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of liquid water mass mixing ratio with respect to moist air in the tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array`: Index of mass number concentration of cloud droplets in tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_mass_weighted_rime_factor_in_tracer_concentration_array`: Index of mass weighted rime factor in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_ozone_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of ozone mixing ratio wrt moist air in tracer concentration array
+* `index_of_ozone_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of ozone mass mixing ratio with respect to moist air in the tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_rain_effective_radius_in_xyz_dimensioned_restart_array`: Index of rain effective radius in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_rain_in_tracer_concentration_array`: Index of mass number concentration of rain in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_rain_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of rain mixing ratio wrt moist air in tracer concentration array
+* `index_of_rain_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of rain mass mixing ratio with respect to moist air in the tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_snow_effective_radius_in_xyz_dimensioned_restart_array`: Index of snow effective radius in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_snow_in_tracer_concentration_array`: Index of mass number concentration of snow in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of snow mixing ratio wrt moist air in tracer concentration array
+* `index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of snow mass mixing ratio with respect to moist air in the tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of specific humidity (qv) on previous timestep in xyz dimensioned restart array
+* `index_of_water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of specific humidity (qv) two timesteps back in xyz dimensioned restart array
+* `index_of_water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `control_for_stochastic_land_surface_perturbation`: Control for stochastic land surface perturbation
     * `integer(kind=)`: units = 1
@@ -1062,7 +1062,7 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array`: Index of mass number concentration of hygroscopic aerosols in tracer concentration array
     * `integer(kind=)`: units = index
-* `index_of_water_vapor_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of specific humidity (qv) in tracer concentration array
+* `index_of_water_vapor_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of specific humidity (water vapor mass mixing ratio with respect to moist air) in tracer concentration array
     * `integer(kind=)`: units = index
 * `index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array`: Index of atmosphere heat diffusivity in xyz dimensioned restart array
     * `integer(kind=)`: units = index
@@ -1132,11 +1132,11 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m-3
 * `prescribed_number_concentration_of_cloud_ice`: Prescribed number concentration of cloud ice
     * `real(kind=kind_phys)`: units = m-3
-* `minimum_cloud_condensate_mixing_ratio_wrt_moist_air_threshold`: Minimum cloud condensate mixing ratio wrt moist air threshold
+* `minimum_cloud_condensate_mixing_ratio_wrt_moist_air_threshold`: Minimum threshold cloud condensate mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
-* `minimum_cloud_liquid_water_mixing_ratio_wrt_moist_air_threshold`: Minimum cloud liquid water mixing ratio wrt moist air threshold
+* `minimum_cloud_liquid_water_mixing_ratio_wrt_moist_air_threshold`: Minimum threshold cloud liquid water mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
-* `minimum_cloud_ice_mixing_ratio_wrt_moist_air_threshold`: Minimum cloud ice mixing ratio wrt moist air threshold
+* `minimum_cloud_ice_mixing_ratio_wrt_moist_air_threshold`: Minimum threshold cloud ice mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `relative_humidity_threshold_for_ice_nucleation`: Relative humidity threshold for ice nucleation
     * `real(kind=kind_phys)`: units = fraction
@@ -1375,9 +1375,9 @@ Variables related to the compute environment
 * `filename_of_micm_configuration`: Filename of micm configuration
     * `character(kind=len=*)`: units = none
 ## GFS_typedefs_GFS_interstitial_type
-* `cloud_ice_mixing_ratio_wrt_moist_air_interstitial`: Cloud ice mixing ratio wrt moist air interstitial
+* `cloud_ice_mixing_ratio_wrt_moist_air_interstitial`: Cloud ice mass mixing ratio with respect to moist air in interstitial scheme
     * `real(kind=kind_phys)`: units = kg kg-1
-* `cloud_liquid_water_mixing_ratio_wrt_moist_air_interstitial`: Cloud liquid water mixing ratio wrt moist air interstitial
+* `cloud_liquid_water_mixing_ratio_wrt_moist_air_interstitial`: Cloud liquid water mass mixing ratio with respect to moist air in interstitial scheme
     * `real(kind=kind_phys)`: units = kg kg-1
 * `radiatively_active_gases`: Radiatively active gases
     * `character(kind=len=128)`: units = none
@@ -1385,21 +1385,21 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_liquid_water_particles_in_air`: Process split cumulative tendency of mass number concentration of cloud liquid water particles in air
     * `real(kind=kind_phys)`: units = kg-1 s-1
-* `process_split_cumulative_tendency_of_graupel_mixing_ratio_wrt_moist_air`: Process split cumulative tendency of graupel mixing ratio wrt moist air
+* `process_split_cumulative_tendency_of_graupel_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the graupel mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
-* `process_split_cumulative_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air`: Process split cumulative tendency of cloud ice mixing ratio wrt moist air
+* `process_split_cumulative_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the cloud ice mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols`: Process split cumulative tendency of mass number concentration of nonhygroscopic ice nucleating aerosols
     * `real(kind=kind_phys)`: units = kg-1 s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_air`: Process split cumulative tendency of mass number concentration of cloud ice water crystals in air
     * `real(kind=kind_phys)`: units = kg-1 s-1
-* `process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air`: Process split cumulative tendency of cloud liquid water mixing ratio wrt moist air
+* `process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the cloud liquid water mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
-* `process_split_cumulative_tendency_of_ozone_mixing_ratio_wrt_moist_air`: Process split cumulative tendency of ozone mixing ratio wrt moist air
+* `process_split_cumulative_tendency_of_ozone_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the ozone mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
-* `process_split_cumulative_tendency_of_rain_mixing_ratio_wrt_moist_air`: Process split cumulative tendency of rain mixing ratio wrt moist air
+* `process_split_cumulative_tendency_of_rain_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the rain mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
-* `process_split_cumulative_tendency_of_snow_mixing_ratio_wrt_moist_air`: Process split cumulative tendency of snow mixing ratio wrt moist air
+* `process_split_cumulative_tendency_of_snow_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the snow mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_tracers`: Process split cumulative tendency of tracers
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
@@ -1407,7 +1407,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = J s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols`: Process split cumulative tendency of mass number concentration of hygroscopic aerosols
     * `real(kind=kind_phys)`: units = kg-1 s-1
-* `process_split_cumulative_tendency_of_water_vapor_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of specific humidity (qv)
+* `process_split_cumulative_tendency_of_water_vapor_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of specific humidity (water vapor mass mixing ratio with respect to moist air)
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_x_wind`: Process split cumulative tendency of x wind
     * `real(kind=kind_phys)`: units = m s-2
@@ -1438,7 +1438,7 @@ Variables related to the compute environment
     * `integer(kind=)`: units = count
 * `convective_cloud_area_fraction`: Convective cloud area fraction
     * `real(kind=kind_phys)`: units = fraction
-* `convective_cloud_condensate_mixing_ratio_wrt_moist_air`: Convective cloud condensate mixing ratio wrt moist air
+* `convective_cloud_condensate_mixing_ratio_wrt_moist_air`: Convective cloud condensate mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `effective_radius_of_stratiform_cloud_graupel_particle`: Effective radius of stratiform cloud graupel particle
     * `real(kind=kind_phys)`: units = um
@@ -1458,7 +1458,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg-1
 * `upward_virtual_potential_temperature_flux`: Upward virtual potential temperature flux
     * `real(kind=kind_phys)`: units = K m s-1
-* `upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_mellor_yamada_janjic_surface_layer_scheme`: Upward flux of specific humidity (qv) at surface for MYJ surface layer scheme
+* `upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_mellor_yamada_janjic_surface_layer_scheme`: Upward flux of specific humidity (water vapor mass mixing ratio with respect to moist air) at surface for MYJ surface layer scheme
     * `real(kind=kind_phys)`: units = m s-1 kg kg-1
 * `cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative max vertical index at cloud base between sw radiation calls
     * `real(kind=kind_phys)`: units = 1
@@ -1468,9 +1468,9 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `turbulent_mixing_length`: Turbulent mixing length
     * `real(kind=kind_phys)`: units = m
-* `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep`: Specific humidity (qv) on previous timestep
+* `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep`: Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep
     * `real(kind=kind_phys)`: units = kg kg-1
-* `tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_nonphysics`: Tendency of specific humidity (qv) due to nonphysics
+* `tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_nonphysics`: Tendency of specific humidity (water vapor mass mixing ratio with respect to moist air) due to nonphysics
     * `real(kind=kind_phys)`: units = kg kg-1 s-1
 * `momentum_exchange_coefficient_for_myj_schemes`: Momentum exchange coefficient for myj schemes
     * `real(kind=kind_phys)`: units = m s-1
@@ -1478,7 +1478,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = various
 * `air_potential_temperature_at_top_of_viscous_sublayer`: Air potential temperature at top of viscous sublayer
     * `real(kind=kind_phys)`: units = K
-* `variance_of_water_vapor_mixing_ratio_wrt_moist_air`: Variance of specific humidity (qv)
+* `variance_of_water_vapor_mixing_ratio_wrt_moist_air`: Variance of specific humidity (water vapor mass mixing ratio with respect to moist air)
     * `real(kind=kind_phys)`: units = kg2 kg-2
 * `random_number`: Random number
     * `real(kind=kind_phys)`: units = 1
@@ -1488,15 +1488,15 @@ Variables related to the compute environment
     * `integer(kind=)`: units = 1
 * `cumulative_min_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative min vertical index at cloud base between sw radiation calls
     * `real(kind=kind_phys)`: units = 1
-* `water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Water vapor mixing ratio wrt moist air at top of viscous sublayer
+* `water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer
     * `real(kind=kind_phys)`: units = kg kg-1
 * `stability_function_for_heat`: Stability function for heat
     * `real(kind=kind_phys)`: units = 1
 * `subgrid_scale_cloud_area_fraction_in_atmosphere_layer`: Subgrid scale cloud area fraction in atmosphere layer
     * `real(kind=kind_phys)`: units = fraction
-* `subgrid_scale_cloud_ice_mixing_ratio_wrt_moist_air`: Subgrid scale cloud ice mixing ratio wrt moist air
+* `subgrid_scale_cloud_ice_mixing_ratio_wrt_moist_air`: Subgrid-scale cloud ice mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
-* `subgrid_scale_cloud_liquid_water_mixing_ratio_wrt_moist_air`: Subgrid scale cloud liquid water mixing ratio wrt moist air
+* `subgrid_scale_cloud_liquid_water_mixing_ratio_wrt_moist_air`: Subgrid-scale cloud liquid water mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `subgrid_scale_cloud_fraction_from_shoc`: Subgrid scale cloud fraction from shoc
     * `real(kind=kind_phys)`: units = fraction
@@ -1506,11 +1506,11 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = Pa
 * `control_for_surface_layer_evaporation`: Control for surface layer evaporation
     * `real(kind=kind_phys)`: units = 1
-* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_schemes`: Surface specific humidity (qv) for MYJ schemes
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_schemes`: Surface specific humidity (water vapor mass mixing ratio with respect to moist air) for MYJ schemes
     * `real(kind=kind_phys)`: units = kg kg-1
 * `enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convection`: Enhancement to wind speed at surface adjacent layer due to convection
     * `real(kind=kind_phys)`: units = m s-1
-* `covariance_of_air_temperature_and_water_vapor_mixing_ratio_wrt_moist_air`: Covariance of air temperature and specific humidity (qv)
+* `covariance_of_air_temperature_and_water_vapor_mixing_ratio_wrt_moist_air`: Covariance of air temperature and specific humidity (water vapor mass mixing ratio with respect to moist air)
     * `real(kind=kind_phys)`: units = K kg kg-1
 * `variance_of_air_temperature`: Variance of air temperature
     * `real(kind=kind_phys)`: units = K2
@@ -1530,15 +1530,15 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m s-1
 * `y_wind_at_top_of_viscous_sublayer`: Y wind at top of viscous sublayer
     * `real(kind=kind_phys)`: units = m s-1
-* `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Specific humidity (qv) on previous timestep in XYZ-dimensioned restart array
+* `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in XYZ-dimensioned restart array
     * `real(kind=kind_phys)`: units = kg kg-1
-* `water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back`: Specific humidity (qv) two timesteps back
+* `water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back`: Specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back
     * `real(kind=kind_phys)`: units = kg kg-1
 * `weight_for_momentum_at_top_of_viscous_sublayer`: Weight for momentum at top of viscous sublayer
     * `real(kind=kind_phys)`: units = 1
 * `weight_for_potential_temperature_at_top_of_viscous_sublayer`: Weight for potential temperature at top of viscous sublayer
     * `real(kind=kind_phys)`: units = 1
-* `weight_for_water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Weight for specific humidity (qv) at the top of the viscous sublayer
+* `weight_for_water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Weight for specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer
     * `real(kind=kind_phys)`: units = 1
 ## GFS_typedefs_GFS_sfcprop_type
 * `wet_canopy_area_fraction`: Wet canopy area fraction
@@ -1557,9 +1557,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = mm
 * `canopy_water_amount`: Canopy water amount
     * `real(kind=kind_phys)`: units = kg m-2
-* `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_ice`: Cloud condensed water mixing ratio wrt moist air at surface over ice
+* `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_ice`: Cloud condensed water mass mixing ratio with respect to moist air at surface over ice
     * `real(kind=kind_phys)`: units = kg kg-1
-* `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land`: Cloud condensed water mixing ratio wrt moist air at surface over land
+* `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land`: Cloud condensed water mass mixing ratio with respect to moist air at surface over land
     * `real(kind=kind_phys)`: units = kg kg-1
 * `coefficient_c_0`: Coefficient c 0
     * `real(kind=kind_phys)`: units = 1
@@ -1727,11 +1727,11 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K
 * `volumetric_soil_moisture_between_soil_bottom_and_water_table`: Volumetric soil moisture between soil bottom and water table
     * `real(kind=kind_phys)`: units = m3 m-3
-* `water_vapor_mixing_ratio_wrt_moist_air_at_2m`: Specific humidity (qv) at two meters above surface
+* `water_vapor_mixing_ratio_wrt_moist_air_at_2m`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at two meters above surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m`: mixing ratio of the mass of water vapor to the mass of moist air and hydrometeors, at two meters above surface
     * `real(kind=kind_phys)`: units = kg kg-1
-* `specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specified upward specific humidity (qv) flux at surface
+* `specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specified upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface
     * `real(kind=kind_phys)`: units = kg kg-1 m s-1
 * `specified_upward_temperature_flux_at_surface`: Specified upward temperature flux at surface
     * `real(kind=kind_phys)`: units = K m s-1
@@ -1811,7 +1811,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `lwe_surface_snow`: Lwe surface snow
     * `real(kind=kind_phys)`: units = mm
-* `water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specific humidity (qv) at surface
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface
     * `real(kind=kind_phys)`: units = kg kg-1
 * `ratio_of_height_to_monin_obukhov_length`: Ratio of height to monin obukhov length
     * `real(kind=kind_phys)`: units = 1
@@ -1853,9 +1853,9 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m
 * `water_table_recharge_assuming_shallow`: Water table recharge assuming shallow
     * `real(kind=kind_phys)`: units = m
-* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_ice`: Water vapor mixing ratio wrt moist air at surface over ice
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_ice`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over ice
     * `real(kind=kind_phys)`: units = kg kg-1
-* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_land`: Water vapor mixing ratio wrt moist air at surface over land
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_land`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over land
     * `real(kind=kind_phys)`: units = kg kg-1
 * `wood_mass_content`: Wood mass content
     * `real(kind=kind_phys)`: units = g m-2
@@ -1900,7 +1900,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `atmosphere_heat_diffusivity_for_chemistry_coupling`: Atmosphere heat diffusivity for chemistry coupling
     * `real(kind=kind_phys)`: units = m2 s-1
-* `water_vapor_mixing_ratio_wrt_moist_air_at_2m_for_coupling`: Specific humidity (qv) at 2 meters above surface used for coupling
+* `water_vapor_mixing_ratio_wrt_moist_air_at_2m_for_coupling`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at 2 meters above surface used for coupling
     * `real(kind=kind_phys)`: units = kg kg-1
 * `air_pressure_at_surface_for_coupling`: Air pressure at surface for coupling
     * `real(kind=kind_phys)`: units = Pa
@@ -2033,7 +2033,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = Pa
 * `air_temperature_at_surface_adjacent_layer`: Air temperature at surface adjacent layer
     * `real(kind=kind_phys)`: units = K
-* `cloud_liquid_water_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer`: Cloud liquid water mixing ratio wrt moist air at surface adjacent layer
+* `cloud_liquid_water_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer`: Cloud liquid water mass mixing ratio with respect to moist air at surface-adjacent layer
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air`: Mass number concentration of cloud liquid water particles in air
     * `real(kind=kind_phys)`: units = kg-1
@@ -2049,7 +2049,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m2 s-2
 * `geopotential_at_interfaces`: Geopotential at interfaces
     * `real(kind=kind_phys)`: units = m2 s-2
-* `graupel_mixing_ratio_wrt_moist_air`: Graupel mixing ratio wrt moist air
+* `graupel_mixing_ratio_wrt_moist_air`: Graupel mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_graupel_in_air`: Mass number concentration of graupel in air
     * `real(kind=kind_phys)`: units = kg-1
@@ -2057,13 +2057,13 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg-1
 * `mass_number_concentration_of_cloud_ice_water_crystals_in_air`: Mass number concentration of cloud ice water crystals in air
     * `real(kind=kind_phys)`: units = kg-1
-* `ozone_mixing_ratio_wrt_moist_air`: Ozone mixing ratio wrt moist air
+* `ozone_mixing_ratio_wrt_moist_air`: Ozone mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_rain_water_in_air`: Mass number concentration of rain water in air
     * `real(kind=kind_phys)`: units = kg-1
 * `mass_number_concentration_of_snow_in_air`: Mass number concentration of snow in air
     * `real(kind=kind_phys)`: units = kg-1
-* `snow_mixing_ratio_wrt_moist_air`: Snow mixing ratio wrt moist air
+* `snow_mixing_ratio_wrt_moist_air`: Snow mass mixing ratio with respect to moist air
     * `real(kind=kind_phys)`: units = kg kg-1
 * `tracer_concentration`: Tracer concentration
     * `real(kind=kind_phys)`: units = kg kg-1
@@ -2071,7 +2071,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = J
 * `mass_number_concentration_of_hygroscopic_aerosols`: Mass number concentration of hygroscopic aerosols
     * `real(kind=kind_phys)`: units = kg-1
-* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer`: Specific humidity (qv) at surface-adjacent layer
+* `water_vapor_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface-adjacent layer
     * `real(kind=kind_phys)`: units = kg kg-1
 * `x_wind_at_surface_adjacent_layer`: X wind at surface adjacent layer
     * `real(kind=kind_phys)`: units = m s-1
@@ -2165,13 +2165,13 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K
 * `air_temperature_of_new_state`: Air temperature of new state
     * `real(kind=kind_phys)`: units = K
-* `cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state`: Cloud liquid water mixing ratio wrt moist air of new state
+* `cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state`: Cloud liquid water mass mixing ratio with respect to moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state`: Mass number concentration of cloud liquid water particles in air of new state
     * `real(kind=kind_phys)`: units = kg-1
 * `nonconvective_cloud_area_fraction_in_atmosphere_layer_of_new_state`: Nonconvective cloud area fraction in atmosphere layer of new state
     * `real(kind=kind_phys)`: units = fraction
-* `graupel_mixing_ratio_wrt_moist_air_of_new_state`: Graupel mixing ratio wrt moist air of new state
+* `graupel_mixing_ratio_wrt_moist_air_of_new_state`: Graupel mass mixing ratio with respect to moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_graupel_of_new_state`: Mass number concentration of graupel of new state
     * `real(kind=kind_phys)`: units = kg-1
@@ -2179,7 +2179,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg-1
 * `mass_number_concentration_of_cloud_ice_water_crystals_in_air_of_new_state`: Mass number concentration of cloud ice water crystals in air of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `cloud_ice_mixing_ratio_wrt_moist_air_of_new_state`: Cloud ice mixing ratio wrt moist air of new state
+* `cloud_ice_mixing_ratio_wrt_moist_air_of_new_state`: Cloud ice mass mixing ratio with respect to moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_weighted_rime_factor_of_new_state`: Mass weighted rime factor of new state
     * `real(kind=kind_phys)`: units = kg kg-1
@@ -2187,19 +2187,19 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_rain_of_new_state`: Mass number concentration of rain of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `rain_mixing_ratio_wrt_moist_air_of_new_state`: Rain mixing ratio wrt moist air of new state
+* `rain_mixing_ratio_wrt_moist_air_of_new_state`: Rain mass mixing ratio with respect to moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_snow_of_new_state`: Mass number concentration of snow of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `snow_mixing_ratio_wrt_moist_air_of_new_state`: Snow mixing ratio wrt moist air of new state
+* `snow_mixing_ratio_wrt_moist_air_of_new_state`: Snow mass mixing ratio with respect to moist air of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `tracer_concentration_of_new_state`: Tracer concentration of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `mass_number_concentration_of_hygroscopic_aerosols_of_new_state`: Mass number concentration of hygroscopic aerosols of new state
     * `real(kind=kind_phys)`: units = kg-1
-* `water_vapor_mixing_ratio_wrt_moist_air_of_new_state_at_surface_adjacent_layer`: Specific humidity (qv) of new state at surface-adjacent layer
+* `water_vapor_mixing_ratio_wrt_moist_air_of_new_state_at_surface_adjacent_layer`: Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state at surface-adjacent layer
     * `real(kind=kind_phys)`: units = kg kg-1
-* `water_vapor_mixing_ratio_wrt_moist_air_of_new_state`: Specific humidity (qv) of new state
+* `water_vapor_mixing_ratio_wrt_moist_air_of_new_state`: Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state
     * `real(kind=kind_phys)`: units = kg kg-1
 * `x_wind_of_new_state_at_surface_adjacent_layer`: X wind of new state at surface adjacent layer
     * `real(kind=kind_phys)`: units = m s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -1783,7 +1783,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m s-1
 * `surface_friction_velocity_for_momentum`: Surface friction velocity for momentum
     * `real(kind=kind_phys)`: units = m s-1
-* `surface_upward_latent_heat_flux`: Surface upward latent heat flux
+* `upward_latent_heat_flux_at_surface`: Upward latent heat flux at surface
     * `real(kind=kind_phys)`: units = W m-2
 * `surface_longwave_emissivity_over_ice`: Surface longwave emissivity over ice
     * `real(kind=kind_phys)`: units = fraction
@@ -1864,37 +1864,37 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `convective_cloud_condensate_after_rainout`: Convective cloud condensate after rainout
     * `real(kind=kind_phys)`: units = kg kg-1
-* `cumulative_surface_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling diffuse nir shortwave flux for coupling multiplied by timestep
+* `cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling diffuse nir shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling diffuse uv and vis shortwave flux for coupling multiplied by timestep
+* `cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling diffuse uv and vis shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_downwelling_direct_nir_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling direct nir shortwave flux for coupling multiplied by timestep
+* `cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling direct nir shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling direct uv and vis shortwave flux for coupling multiplied by timestep
+* `cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling direct uv and vis shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_downwelling_longwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling longwave flux for coupling multiplied by timestep
+* `cumulative_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling longwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling shortwave flux for coupling multiplied by timestep
+* `cumulative_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_net_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling diffuse nir shortwave flux for coupling multiplied by timestep
+* `cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling diffuse nir shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling diffuse uv and vis shortwave flux for coupling multiplied by timestep
+* `cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling diffuse uv and vis shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_net_downwelling_direct_nir_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling direct nir shortwave flux for coupling multiplied by timestep
+* `cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling direct nir shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_net_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling direct uv and vis shortwave flux for coupling multiplied by timestep
+* `cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling direct uv and vis shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_net_downwelling_longwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling longwave flux for coupling multiplied by timestep
+* `cumulative_net_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling longwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_net_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling shortwave flux for coupling multiplied by timestep
+* `cumulative_net_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling shortwave flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_upward_latent_heat_flux_for_coupling_multiplied_by_timestep`: Cumulative surface upward latent heat flux for coupling multiplied by timestep
+* `cumulative_upward_latent_heat_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative upward latent heat flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_upward_sensible_heat_flux_for_coupling_multiplied_by_timestep`: Cumulative surface upward sensible heat flux for coupling multiplied by timestep
+* `cumulative_upward_sensible_heat_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative upward sensible heat flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_x_momentum_flux_for_coupling_multiplied_by_timestep`: Cumulative surface x momentum flux for coupling multiplied by timestep
+* `cumulative_x_momentum_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative x momentum flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = Pa s
-* `cumulative_surface_y_momentum_flux_for_coupling_multiplied_by_timestep`: Cumulative surface y momentum flux for coupling multiplied by timestep
+* `cumulative_y_momentum_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative y momentum flux at surface for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = Pa s
 * `cellular_automata_area_fraction_for_deep_convection_from_coupled_process`: Cellular automata area fraction for deep convection from coupled process
     * `real(kind=kind_phys)`: units = fraction
@@ -1904,41 +1904,41 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `air_pressure_at_surface_for_coupling`: Air pressure at surface for coupling
     * `real(kind=kind_phys)`: units = Pa
-* `surface_downwelling_diffuse_nir_shortwave_flux_for_coupling`: Surface downwelling diffuse nir shortwave flux for coupling
+* `downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: Downwelling diffuse nir shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling`: Surface downwelling diffuse uv and vis shortwave flux for coupling
+* `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Downwelling diffuse uv and vis shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_direct_nir_shortwave_flux_for_coupling`: Surface downwelling direct nir shortwave flux for coupling
+* `downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: Downwelling direct nir shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling`: Surface downwelling direct uv and vis shortwave flux for coupling
+* `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Downwelling direct uv and vis shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_longwave_flux_for_coupling`: Surface downwelling longwave flux for coupling
+* `downwelling_longwave_flux_at_surface_for_coupling`: Downwelling longwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_shortwave_flux_for_coupling`: Surface downwelling shortwave flux for coupling
+* `downwelling_shortwave_flux_at_surface_for_coupling`: Downwelling shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_net_downwelling_diffuse_nir_shortwave_flux_for_coupling`: Surface net downwelling diffuse nir shortwave flux for coupling
+* `net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: Net downwelling diffuse nir shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling`: Surface net downwelling diffuse uv and vis shortwave flux for coupling
+* `net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Net downwelling diffuse uv and vis shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_net_downwelling_direct_nir_shortwave_flux_for_coupling`: Surface net downwelling direct nir shortwave flux for coupling
+* `net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: Net downwelling direct nir shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_net_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling`: Surface net downwelling direct uv and vis shortwave flux for coupling
+* `net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: Net downwelling direct uv and vis shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_net_downwelling_longwave_flux_for_coupling`: Surface net downwelling longwave flux for coupling
+* `net_downwelling_longwave_flux_at_surface_for_coupling`: Net downwelling longwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_net_downwelling_shortwave_flux_for_coupling`: Surface net downwelling shortwave flux for coupling
+* `net_downwelling_shortwave_flux_at_surface_for_coupling`: Net downwelling shortwave flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
 * `surface_skin_temperature_for_coupling`: Surface skin temperature for coupling
     * `real(kind=kind_phys)`: units = K
-* `surface_upward_latent_heat_flux_for_coupling`: Surface upward latent heat flux for coupling
+* `upward_latent_heat_flux_at_surface_for_coupling`: Upward latent heat flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upward_sensible_heat_flux_for_chemistry_coupling`: Surface upward sensible heat flux for chemistry coupling
+* `upward_sensible_heat_flux_at_surface_for_chemistry_coupling`: Upward sensible heat flux at surface for chemistry coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upward_sensible_heat_flux_for_coupling`: Surface upward sensible heat flux for coupling
+* `upward_sensible_heat_flux_at_surface_for_coupling`: Upward sensible heat flux at surface for coupling
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_x_momentum_flux_for_coupling`: Surface x momentum flux for coupling
+* `x_momentum_flux_at_surface_for_coupling`: X momentum flux at surface for coupling
     * `real(kind=kind_phys)`: units = Pa
-* `surface_y_momentum_flux_for_coupling`: Surface y momentum flux for coupling
+* `y_momentum_flux_at_surface_for_coupling`: Y momentum flux at surface for coupling
     * `real(kind=kind_phys)`: units = Pa
 * `temperature_at_2m_for_coupling`: Temperature at 2m for coupling
     * `real(kind=kind_phys)`: units = K
@@ -1964,19 +1964,19 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = W m-2
 * `area_type_from_coupled_process`: Area type from coupled process
     * `real(kind=kind_phys)`: units = 1
-* `surface_downwelling_diffuse_nir_shortwave_flux_on_radiation_timestep`: Surface downwelling diffuse nir shortwave flux on radiation timestep
+* `downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling diffuse nir shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_diffuse_uv_and_vis_shortwave_flux_on_radiation_timestep`: Surface downwelling diffuse uv and vis shortwave flux on radiation timestep
+* `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling diffuse uv and vis shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_direct_nir_shortwave_flux_on_radiation_timestep`: Surface downwelling direct nir shortwave flux on radiation timestep
+* `downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling direct nir shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_direct_uv_and_vis_shortwave_flux_on_radiation_timestep`: Surface downwelling direct uv and vis shortwave flux on radiation timestep
+* `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling direct uv and vis shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_longwave_flux_on_radiation_timestep`: Surface downwelling longwave flux on radiation timestep
+* `downwelling_longwave_flux_at_surface_on_radiation_timestep`: Downwelling longwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_downwelling_shortwave_flux_on_radiation_timestep`: Surface downwelling shortwave flux on radiation timestep
+* `downwelling_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_net_downwelling_shortwave_flux_on_radiation_timestep`: Surface net downwelling shortwave flux on radiation timestep
+* `net_downwelling_shortwave_flux_at_surface_on_radiation_timestep`: Net downwelling shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
 * `diffuse_nir_albedo_for_coupling`: surface albedo for diffuse near-infrared radiation for coupling
     * `real(kind=kind_phys)`: units = fraction
@@ -1984,21 +1984,21 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = fraction
 * `lwe_surface_snow_from_coupled_process`: Lwe surface snow from coupled process
     * `real(kind=kind_phys)`: units = m
-* `surface_upward_latent_heat_flux_from_coupled_process`: Surface upward latent heat flux from coupled process
+* `upward_latent_heat_flux_at_surface_from_coupled_process`: Upward latent heat flux at surface from coupled process
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upward_sensible_heat_flux_from_coupled_process`: Surface upward sensible heat flux from coupled process
+* `upward_sensible_heat_flux_at_surface_from_coupled_process`: Upward sensible heat flux at surface from coupled process
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upwelling_diffuse_nir_shortwave_flux_on_radiation_timestep`: Surface upwelling diffuse nir shortwave flux on radiation timestep
+* `upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling diffuse nir shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upwelling_diffuse_uv_and_vis_shortwave_flux_on_radiation_timestep`: Surface upwelling diffuse uv and vis shortwave flux on radiation timestep
+* `upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling diffuse uv and vis shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upwelling_direct_nir_shortwave_flux_on_radiation_timestep`: Surface upwelling direct nir shortwave flux on radiation timestep
+* `upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling direct nir shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upwelling_direct_uv_and_vis_shortwave_flux_on_radiation_timestep`: Surface upwelling direct uv and vis shortwave flux on radiation timestep
+* `upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: Upwelling direct uv and vis shortwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upwelling_longwave_flux_from_coupled_process`: Surface upwelling longwave flux from coupled process
+* `upwelling_longwave_flux_at_surface_from_coupled_process`: Upwelling longwave flux at surface from coupled process
     * `real(kind=kind_phys)`: units = W m-2
-* `surface_upwelling_longwave_flux_on_radiation_timestep`: Surface upwelling longwave flux on radiation timestep
+* `upwelling_longwave_flux_at_surface_on_radiation_timestep`: Upwelling longwave flux at surface on radiation timestep
     * `real(kind=kind_phys)`: units = W m-2
 * `diffuse_visible_albedo_for_coupling`: surface albedo for diffuse visible radiation for coupling
     * `real(kind=kind_phys)`: units = fraction

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -132,13 +132,13 @@ These are the base names for specific chemical species
 * `hydrophilic_organic_carbon`: hydrophilic_organic_carbon
 * `hydrophobic_organic_carbon`: hydrophobic_organic_carbon
 * `methane`: ch4
-* `n2o`: Nitrous Oxide, N₂O
+* `n2o`: Nitrous Oxide, N_2O
 * `nitrate`: Chemical species containing the nitrate ion
 * `nitrite`: Chemical species containing the nitrite ion
 * `no2`: Nitrogen dioxide
 * `no`: Nitric oxide NO (Nitrogen oxide, Nitrogen monoxide)
-* `oxygen`: Molecular oxygen, O₂
-* `ozone`: Ozone, O₃
+* `oxygen`: Molecular oxygen, O_2
+* `ozone`: Ozone, O_3
 * `phosphate`: Chemical species containing the phosphate ion
 * `silicate`: Chemical species containing the silicate ion
 * `sulfate`: Chemical species containing the sulfate ion

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -35,12 +35,12 @@ CCPP Standard Name Rules
    [``transformation``] [``component``] base_name [*at* ``level``] [*in* ``medium``] [*due_to* ``process``] [*assuming* ``condition``]
 
    This construction was originally based on rules set forth in the
-   `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`_),
+   `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`),
    but have since evolved for better consistency and generality across a broader set of fields
    than was originally envisioned by the CF conventions. "``medium``" should be specified when
-   the variable in question is a substance or other quantity contained within some other medium
-   (e.g. for "mole_fraction_of_ozone_in_air", the base name is "ozone", while the medium is "air"). 
-   "Transformation" refers to descriptors such as "``tendency_of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_.
+   the variable in question is a substance or other quantity contained within some other the medium
+   (e.g. for with air as the medium, mole_fraction_of_ozone_in_air, the base name is ozone, while the medium is air). 
+   "Transformation" refers to descriptors such as "``tendency of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable.
    Other parts of the construction provide information about a variable's horizontal surface
    (e.g. ``at_cloud_base``), component (i.e. direction of variable, e.g. ``downward``), process (e.g.
    ``due_to_deep_convection``), or condition (e.g., ``assuming_clear_sky``). These qualifications do not
@@ -50,8 +50,7 @@ CCPP Standard Name Rules
    The following table provides a few concrete examples of standard names and how they are constructed
    with respect to the guideline template.
 
-.. image:: https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_construction_examples.png
-   :alt: image of table providing standard name construction examples
+   ![image of table providing standard name construction examples](https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_construction_examples.png)
 
 #. Variables are current and instantaneous unless specified. Variables that are not
    current (e.g., previous timestep) or non-instantaneous (e.g., accumulated values)
@@ -120,7 +119,7 @@ CCPP Standard Name Rules
    *cloud_at_500hPa* if only including clouds that exist at 500 hPa).
 
 #. If possible, qualifiers should be limited in order to allow for a wide
-   applicability of the variable. In other words, don't qualify with ``_for_specific_context``
+   applicability of the variable. In other words, don't qualify with ``_for_xyz``
    unless a variable could not conceivably be used outside of the more
    narrowly-defined context or a variable without the scope-narrowing qualifiers
    already exists and cannot be reused.

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -50,7 +50,8 @@ CCPP Standard Name Rules
    The following table provides a few concrete examples of standard names and how they are constructed
    with respect to the guideline template.
 
-   ![image of table providing standard name construction examples](https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_construction_examples.png)
+.. image:: https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_construction_examples.png
+   :alt: image of table providing standard name construction examples
 
 #. Variables are current and instantaneous unless specified. Variables that are not
    current (e.g., previous timestep) or non-instantaneous (e.g., accumulated values)

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -32,14 +32,14 @@ CCPP Standard Name Rules
    while the words in ``this font`` indicate other words or phrases to be substituted.
    The new standard name is constructed by joining the base standard name to the qualifiers using underscores.
 
-   [``transformation``] [``component``] base_name [*at* ``level``] [*in* ``medium``] [*due_to* ``process``] [*assuming* ``condition``]
+   [``transformation``] [``component``] [``non-instant time``] base_name [*in* ``medium``] [*at* ``level``] [*due_to* ``process``] [``non-current time``] [*assuming* ``condition``]
 
    This construction was originally based on rules set forth in the
    `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`_),
    but have since evolved for better consistency and generality across a broader set of fields
    than was originally envisioned by the CF conventions. "``medium``" should be specified when
    the variable in question is a substance or other quantity contained within some other the medium
-   (e.g. for with air as the medium, mole_fraction_of_ozone_in_air, the base name is ozone, while the medium is air). 
+   (e.g. for ``mole_fraction_of_ozone_in_air``, the base name is "ozone", while the medium is "air"). 
    "Transformation" refers to descriptors such as "``tendency_of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_.
    Other parts of the construction provide information about a variable's horizontal surface
    (e.g. ``at_cloud_base``), component (i.e. direction of variable, e.g. ``downward``), process (e.g.
@@ -52,6 +52,19 @@ CCPP Standard Name Rules
 
 .. image:: https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_construction_examples.png
    :alt: image of table providing standard name construction examples
+
+   Note that "transformations" are a special case, where multiple transformations may be applied,
+   and multiple quantities may be compared, operated on, etc. For transformations involving
+   multiple quantities (e.g. ``ratio_of_X_to_Y``; see the `section on Transformations <#transformations>`_
+   for more information), the above formula may be extended around multiple base names.
+
+.. image:: https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_transformation_examples.png
+   :alt: image of table providing standard name construction examples with multiple transformations
+
+   In the latter example, ``ln`` is operating on the quantity ``water_vapor_partial_pressure_assuming_saturation``,
+   while ``derivative_of`` is a combined transformation of ``water_vapor_partial_pressure_assuming_saturation``
+   and ``air_temperature``. When multiple transformations are present, a more detailed description
+   should be provided in the ``long_name`` field to prevent any possible ambiguity.
 
 #. Variables are current and instantaneous unless specified. Variables that are not
    current (e.g., previous timestep) or non-instantaneous (e.g., accumulated values)
@@ -87,14 +100,15 @@ CCPP Standard Name Rules
    with respect to what quantity they are defined, and options are *wrt_dry_air*,
    *wrt_moist_air*, or *wrt_moist_air_and_condensed_water*, where *moist_air*
    refers to dry air plus vapor and *moist_air_and_condensed_water* refers
-   to dry air plus vapor and hydrometeors. Use of the term *specific_humidity* should
-   be avoided as there is no consensus on whether it refers to
-   *water_vapor_mixing_ratio_wrt_moist_air* or
+   to dry air plus vapor and hydrometeors.
+
+   Use of the term *specific_humidity* should be avoided, as there is no consensus on
+   whether it refers to *water_vapor_mixing_ratio_wrt_moist_air* or
    *water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water*.
    *total_water* can be used to designate water in every form, i.e. water
    vapor plus condensed water.
 
-#. Volume mixing ratios should be qualified as *volume_mixing_ratio*.
+   Volume mixing ratios should be qualified as *volume_mixing_ratio*.
 
 #. By default, *mole_fraction_of_X_in_Y* refers to the total amount of *Y*. So, for example,
    *mole_fraction_of_ozone_in_air* refers to the total amount of (moist) air. (In the case of air,
@@ -311,6 +325,7 @@ Suffixes
 | **on_radiation_timestep**
 | **on_previous_timestep**
 | ``N`` **_timesteps_back**
+| **since_** ``T``
 
 Computational
 -------------
@@ -372,6 +387,7 @@ Prefixes
 | change_over_time_in ``_X``
 | convergence_of ``_X`` or horizontal_convergence_of ``_X``
 | correlation_of ``_X`` _and ``_Y`` [_over ``_Z``]
+| cosine_of ``_X``
 | covariance_of ``_X`` _and ``_Y`` [_over ``_Z``]
 | component_derivative_of ``_X``
 | derivative_of ``_X`` _wrt ``_Y``
@@ -381,18 +397,19 @@ Prefixes
 | integral_of ``_Y`` _wrt ``_X``
 | ln ``_X``
 | log10 ``_X``
+| lwe_thickness_of ``_X``
 | magnitude_of ``_X``
 | probability_distribution_of ``_X`` [_over ``_Z``]
 | probability_density_function_of ``_X`` [_over ``_Z``]
 | product_of ``_X`` _and ``_Y``
 | ratio_of ``_X`` _to ``_Y``
+| reciprocal_of ``_X``
+| sine_of ``_X``
 | square_of ``_X``
+| standard_deviation_of ``_X``
 | tendency_of ``_X``
-| **standard_deviation_of** ``_X``
-| **reciprocal_of** ``_X``
-| **cosine_of** ``_X``
-| **sine_of** ``_X``
-| **variance_of** ``_X``
+| variance_of ``_X``
+| volume_mixing_ratio_of ``_X``
 
 Suffixes
 ^^^^^^^^
@@ -429,13 +446,13 @@ Special phrases
 +------------------------+-------------------------------------------------------------------------------------+
 |frozen_water            | ice                                                                                 |
 +------------------------+-------------------------------------------------------------------------------------+
-| longwave               | longwave radiation                                                                  |
+| longwave               | Longwave radiation. Defined as thermal emission of EM radiation from the planet.    |
 +------------------------+-------------------------------------------------------------------------------------+
 | moisture               | water in all phases contained in soil                                               |
 +------------------------+-------------------------------------------------------------------------------------+
 | ocean                  | used instead of in_sea_water for quantities which are large-scale rather than local |
 +------------------------+-------------------------------------------------------------------------------------+
-| shortwave              | shortwave radiation                                                                 |
+| shortwave              | Shortwave radiation. Defined as EM emissions from the sun                           |
 +------------------------+-------------------------------------------------------------------------------------+
 | specific               | per unit mass unless otherwise stated                                               |
 +------------------------+-------------------------------------------------------------------------------------+

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -40,7 +40,7 @@ CCPP Standard Name Rules
    than was originally envisioned by the CF conventions. "``medium``" should be specified when
    the variable in question is a substance or other quantity contained within some other the medium
    (e.g. for with air as the medium, mole_fraction_of_ozone_in_air, the base name is ozone, while the medium is air). 
-   "Transformation" refers to descriptors such as "``tendency of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_. 
+   "Transformation" refers to descriptors such as "``tendency_of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_.
    Other parts of the construction provide information about a variable's horizontal surface
    (e.g. ``at_cloud_base``), component (i.e. direction of variable, e.g. ``downward``), process (e.g.
    ``due_to_deep_convection``), or condition (e.g., ``assuming_clear_sky``). These qualifications do not

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -35,12 +35,12 @@ CCPP Standard Name Rules
    [``transformation``] [``component``] base_name [*at* ``level``] [*in* ``medium``] [*due_to* ``process``] [*assuming* ``condition``]
 
    This construction was originally based on rules set forth in the
-   `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`),
+   `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`_),
    but have since evolved for better consistency and generality across a broader set of fields
    than was originally envisioned by the CF conventions. "``medium``" should be specified when
    the variable in question is a substance or other quantity contained within some other the medium
    (e.g. for with air as the medium, mole_fraction_of_ozone_in_air, the base name is ozone, while the medium is air). 
-   "Transformation" refers to descriptors such as "``tendency of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable.
+   "Transformation" refers to descriptors such as "``tendency of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_. 
    Other parts of the construction provide information about a variable's horizontal surface
    (e.g. ``at_cloud_base``), component (i.e. direction of variable, e.g. ``downward``), process (e.g.
    ``due_to_deep_convection``), or condition (e.g., ``assuming_clear_sky``). These qualifications do not

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -87,10 +87,10 @@ CCPP Standard Name Rules
    with respect to what quantity they are defined, and options are *wrt_dry_air*,
    *wrt_moist_air*, or *wrt_moist_air_and_condensed_water*, where *moist_air*
    refers to dry air plus vapor and *moist_air_and_condensed_water* refers
-   to dry air plus vapor and hydrometeors. Use of *specific_humidity* should
+   to dry air plus vapor and hydrometeors. Use of the term *specific_humidity* should
    be avoided as there is no consensus on whether it refers to
-   *mixing_ratio_of_water_vapor_wrt_moist_air* or
-   *mixing_ratio_of_water_vapor_wrt_moist_air_and_condensed_water*.
+   *water_vapor_mixing_ratio_wrt_moist_air* or
+   *water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water*.
    *total_water* can be used to designate water in every form, i.e. water
    vapor plus condensed water.
 

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -38,7 +38,7 @@ CCPP Standard Name Rules
    `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`_),
    but have since evolved for better consistency and generality across a broader set of fields
    than was originally envisioned by the CF conventions. "``medium``" should be specified when
-   the variable in question is a substance or other quantity contained within some other the medium
+   the variable in question is a substance or other quantity contained within some other medium
    (e.g. for ``mole_fraction_of_ozone_in_air``, the base name is "ozone", while the medium is "air"). 
    "Transformation" refers to descriptors such as "``tendency_of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_.
    Other parts of the construction provide information about a variable's horizontal surface
@@ -446,13 +446,13 @@ Special phrases
 +------------------------+-------------------------------------------------------------------------------------+
 |frozen_water            | ice                                                                                 |
 +------------------------+-------------------------------------------------------------------------------------+
-| longwave               | Longwave radiation. Defined as thermal emission of EM radiation from the planet.    |
+| longwave               | Longwave radiation. Defined as thermal emission of radiation from the planet.       |
 +------------------------+-------------------------------------------------------------------------------------+
 | moisture               | water in all phases contained in soil                                               |
 +------------------------+-------------------------------------------------------------------------------------+
 | ocean                  | used instead of in_sea_water for quantities which are large-scale rather than local |
 +------------------------+-------------------------------------------------------------------------------------+
-| shortwave              | Shortwave radiation. Defined as EM emissions from the sun                           |
+| shortwave              | Shortwave radiation. Defined as electromagnetic emissions from the sun              |
 +------------------------+-------------------------------------------------------------------------------------+
 | specific               | per unit mass unless otherwise stated                                               |
 +------------------------+-------------------------------------------------------------------------------------+

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -120,7 +120,7 @@ CCPP Standard Name Rules
    *cloud_at_500hPa* if only including clouds that exist at 500 hPa).
 
 #. If possible, qualifiers should be limited in order to allow for a wide
-   applicability of the variable. In other words, don't qualify with ``_for_xyz``
+   applicability of the variable. In other words, don't qualify with ``_for_specific_context``
    unless a variable could not conceivably be used outside of the more
    narrowly-defined context or a variable without the scope-narrowing qualifiers
    already exists and cannot be reused.

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -252,7 +252,7 @@
     <standard_name name="ln_air_pressure_of_dry_air">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="reciprocal_of_dimensionless_exner_function_wrt_surface_air_pressure"
+    <standard_name name="reciprocal_of_exner_function_wrt_surface_air_pressure"
                    long_name="inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
@@ -413,8 +413,8 @@
                    long_name="Reference pressure in atmosphere layer normalized by surface reference pressure">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="dimensionless_exner_function"
-                   long_name="exner function">
+    <standard_name name="exner_function"
+                   long_name="exner function, (p/p0)^(Rd/cp)">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="air_potential_temperature"
@@ -1377,7 +1377,8 @@
       <standard_name name="do_read_surface_albedo_for_diffused_shortwave_from_input">
          <type kind="" units="flag">logical</type>
       </standard_name>
-      <standard_name name="do_limited_surface_roughness_length_over_ocean">
+      <standard_name name="do_limited_roughness_length_over_ocean"
+                   long_name="Do limited surface roughness length over ocean">
          <type kind="" units="flag">logical</type>
       </standard_name>
       <standard_name name="do_reference_pressure_theta">
@@ -2442,7 +2443,8 @@
       <standard_name name="baseline_surface_longwave_emissivity">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="baseline_surface_roughness_length">
+      <standard_name name="baseline_roughness_length"
+                   long_name="Baseline surface roughness length">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
       <standard_name name="air_temperature_in_canopy">
@@ -2811,19 +2813,24 @@
       <standard_name name="surface_longwave_emissivity_over_land">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_roughness_length">
+      <standard_name name="roughness_length"
+                   long_name="surface roughness length">
          <type kind="kind_phys" units="cm">real</type>
       </standard_name>
-      <standard_name name="surface_roughness_length_from_wave_model">
+      <standard_name name="roughness_length_from_wave_model"
+                   long_name="surface roughness length from wave model">
          <type kind="kind_phys" units="cm">real</type>
       </standard_name>
-      <standard_name name="surface_roughness_length_over_ice">
+      <standard_name name="roughness_length_over_ice"
+                   long_name="surface roughness length over ice">
          <type kind="kind_phys" units="cm">real</type>
       </standard_name>
-      <standard_name name="surface_roughness_length_over_land">
+      <standard_name name="roughness_length_over_land"
+                   long_name="surface roughness length over land">
          <type kind="kind_phys" units="cm">real</type>
       </standard_name>
-      <standard_name name="surface_roughness_length_over_water">
+      <standard_name name="roughness_length_over_water"
+                   long_name="surface roughness length over water">
          <type kind="kind_phys" units="cm">real</type>
       </standard_name>
       <standard_name name="surface_skin_temperature">
@@ -3184,13 +3191,16 @@
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="surface_dimensionless_exner_function">
+      <standard_name name="exner_function_wrt_surface_pressure"
+                   long_name="exner function w.r.t. surface pressure, (p/ps)^(Rd/cp)">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="dimensionless_exner_function_at_surface_adjacent_layer">
+      <standard_name name="exner_function_at_surface_adjacent_layer"
+                   long_name="exner function (p/p0)^(Rd/cp), where p0 is the pressure at the surface adjacent layer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="dimensionless_exner_function_at_interfaces">
+      <standard_name name="exner_function_at_interfaces"
+                   long_name="exner function (p/p0)^(Rd/cp), where p0 is the pressure at vertical layer interfaces">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="dissipation_estimate_of_air_temperature_at_model_layers">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -900,7 +900,7 @@
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="exner_function"
-                   long_name="exner function, (p/p0)^(Rd/cp)">
+                   long_name="exner function, (p/p0)^(Rd/cp), where p0 is 1000 hPa">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
     <standard_name name="air_potential_temperature"
@@ -3770,11 +3770,11 @@
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="exner_function_at_surface_adjacent_layer"
-                   long_name="exner function (p/p0)^(Rd/cp), where p0 is the pressure at the surface adjacent layer">
+                   long_name="exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at the surface adjacent layer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="exner_function_at_interfaces"
-                   long_name="exner function (p/p0)^(Rd/cp), where p0 is the pressure at vertical layer interfaces">
+                   long_name="exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at vertical layer interfaces">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="dissipation_estimate_of_air_temperature_at_model_layers">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -27,10 +27,6 @@
                      long_name="coefficient">
         <type units="1">real</type>
       </standard_name>
-      <standard_name name="coefficient"
-                     long_name="coefficient">
-        <type units="1">real</type>
-      </standard_name>
       <standard_name name="data_mask"
                      long_name="data_mask">
         <type units="1">real</type>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -1693,10 +1693,12 @@
       <standard_name name="index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array"
+                   long_name="Index of specific humidity (qv) on previous timestep in xyz dimensioned restart array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_specific_humidity_two_timesteps_back_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back_in_xyz_dimensioned_restart_array"
+                   long_name="Index of specific humidity (qv) two timesteps back in xyz dimensioned restart array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="control_for_stochastic_land_surface_perturbation">
@@ -1717,7 +1719,8 @@
       <standard_name name="index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_specific_humidity_in_tracer_concentration_array">
+      <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
+                   long_name="Index of specific humidity (qv) in tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array">
@@ -2235,7 +2238,8 @@
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols">
          <type kind="kind_phys" units="kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="process_split_cumulative_tendency_of_specific_humidity">
+      <standard_name name="process_split_cumulative_tendency_of_water_vapor_mixing_ratio_wrt_moist_air"
+                   long_name="Process-split cumulative tendency of specific humidity (qv)">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_x_wind">
@@ -2312,7 +2316,8 @@
       <standard_name name="upward_virtual_potential_temperature_flux">
          <type kind="kind_phys" units="K m s-1">real</type>
       </standard_name>
-      <standard_name name="upward_specific_humidity_flux_at_surface_for_mellor_yamada_janjic_surface_layer_scheme">
+      <standard_name name="upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_mellor_yamada_janjic_surface_layer_scheme"
+                   long_name="Upward flux of specific humidity (qv) at surface for MYJ surface layer scheme">
          <type kind="kind_phys" units="m s-1 kg kg-1">real</type>
       </standard_name>
       <standard_name name="cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls">
@@ -2327,10 +2332,12 @@
       <standard_name name="turbulent_mixing_length">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_on_previous_timestep">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep"
+                   long_name="Specific humidity (qv) on previous timestep">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="tendency_of_specific_humidity_due_to_nonphysics">
+      <standard_name name="tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_nonphysics"
+                   long_name="Tendency of specific humidity (qv) due to nonphysics">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="momentum_exchange_coefficient_for_myj_schemes">
@@ -2342,7 +2349,8 @@
       <standard_name name="air_potential_temperature_at_top_of_viscous_sublayer">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="variance_of_specific_humidity">
+      <standard_name name="variance_of_water_vapor_mixing_ratio_wrt_moist_air"
+                   long_name="Variance of specific humidity (qv)">
          <type kind="kind_phys" units="kg2 kg-2">real</type>
       </standard_name>
       <standard_name name="random_number">
@@ -2357,7 +2365,8 @@
       <standard_name name="cumulative_min_vertical_index_at_cloud_base_between_sw_radiation_calls">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_at_top_of_viscous_sublayer">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer">
+                   long_name="Specific humidity (qv) at the top of the viscous sublayer">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="stability_function_for_heat">
@@ -2384,13 +2393,15 @@
       <standard_name name="control_for_surface_layer_evaporation">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="surface_specific_humidity_for_myj_schemes">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_schemes"
+                   long_name="Surface specific humidity (qv) for MYJ schemes">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convection">
          <type kind="kind_phys" units="m s-1">real</type>
       </standard_name>
-      <standard_name name="covariance_of_air_temperature_and_specific_humidity">
+      <standard_name name="covariance_of_air_temperature_and_water_vapor_mixing_ratio_wrt_moist_air"
+                   long_name="Covariance of air temperature and specific humidity (qv)">
          <type kind="kind_phys" units="K kg kg-1">real</type>
       </standard_name>
       <standard_name name="variance_of_air_temperature">
@@ -2420,10 +2431,12 @@
       <standard_name name="y_wind_at_top_of_viscous_sublayer">
          <type kind="kind_phys" units="m s-1">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_on_previous_timestep_in_xyz_dimensioned_restart_array">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array"
+                   long_name="Specific humidity (qv) on previous timestep in XYZ-dimensioned restart array">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_two_timesteps_back">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back"
+                   long_name="Specific humidity (qv) two timesteps back">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="weight_for_momentum_at_top_of_viscous_sublayer">
@@ -2432,7 +2445,8 @@
       <standard_name name="weight_for_potential_temperature_at_top_of_viscous_sublayer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="weight_for_specific_humidity_at_top_of_viscous_sublayer">
+      <standard_name name="weight_for_water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer"
+                   long_name="Weight for specific humidity (qv) at the top of the viscous sublayer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
    </section>
@@ -2546,7 +2560,8 @@
       <standard_name name="temperature_in_ice_layer">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="upward_specific_humidity_flux_at_surface">
+      <standard_name name="upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface">
+                   long_name="Upward specific humidity (qv) flux at surface">
          <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
       </standard_name>
       <standard_name name="upward_temperature_flux_at_surface">
@@ -2723,14 +2738,15 @@
          <type kind="kind_phys" units="m3 m-3">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_2m"
-                     long_name="mixing ratio of the mass of water vapor to the mass of moist air, at two meters above surface">
+                     long_name="Specific humidity (qv) at two meters above surface"> 
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m"
                      long_name="mixing ratio of the mass of water vapor to the mass of moist air and hydrometeors, at two meters above surface">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="specified_upward_specific_humidity_flux_at_surface">
+      <standard_name name="specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface"
+                   long_name="Specified upward specific humidity (qv) flux at surface"> 
          <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
       </standard_name>
       <standard_name name="specified_upward_temperature_flux_at_surface">
@@ -2866,7 +2882,8 @@
       <standard_name name="lwe_surface_snow">
          <type kind="kind_phys" units="mm">real</type>
       </standard_name>
-      <standard_name name="surface_specific_humidity">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface"
+                   long_name="Specific humidity (qv) at surface">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="ratio_of_height_to_monin_obukhov_length">
@@ -3000,7 +3017,8 @@
       <standard_name name="atmosphere_heat_diffusivity_for_chemistry_coupling">
          <type kind="kind_phys" units="m2 s-1">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_at_2m_for_coupling">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_2m_for_coupling"
+                   long_name="Specific humidity (qv) at 2 meters above surface used for coupling">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="air_pressure_at_surface_for_coupling">
@@ -3063,7 +3081,8 @@
       <standard_name name="temperature_at_2m_for_coupling">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="tendency_of_specific_humidity_due_to_moist_convection_for_coupling">
+      <standard_name name="tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_moist_convection_for_coupling">
+                   long_name="Tendency of specific humidity (qv) due to moist convection used for coupling">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="x_wind_at_10m_for_coupling">
@@ -3264,7 +3283,8 @@
       <standard_name name="mass_number_concentration_of_hygroscopic_aerosols">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_at_surface_adjacent_layer">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer"
+                   long_name="Specific humidity (qv) at surface-adjacent layer">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="x_wind_at_surface_adjacent_layer">
@@ -3456,10 +3476,12 @@
       <standard_name name="mass_number_concentration_of_hygroscopic_aerosols_of_new_state">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_of_new_state_at_surface_adjacent_layer">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_of_new_state_at_surface_adjacent_layer"
+                   long_name="Specific humidity (qv) of new state at surface-adjacent layer">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="specific_humidity_of_new_state">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_of_new_state"
+                   long_name="Specific humidity (qv) of new state">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="x_wind_of_new_state_at_surface_adjacent_layer">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -2591,16 +2591,20 @@
       <standard_name name="max_vegetation_area_fraction">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="nir_albedo_strong_cosz">
+      <standard_name name="nir_albedo_strong_cosz"
+                     long_name="albedo for near-infrared radiation with strong dependence on cosine of the zenith angle">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="nir_albedo_weak_cosz">
+                     long_name="albedo for near-infrared radiation with weak dependence on cosine of the zenith angle">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="vis_albedo_strong_cosz">
+                     long_name="albedo for visible radiation with strong dependence on cosine of the zenith angle">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="vis_albedo_weak_cosz">
+                     long_name="albedo for visible radiation with weak dependence on cosine of the zenith angle">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="min_vegetation_area_fraction">
@@ -2682,7 +2686,7 @@
       <standard_name name="slow_soil_pool_mass_content_of_carbon">
          <type kind="kind_phys" units="g m-2">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_assuming_deep_snow_on_previous_timestep">
+      <standard_name name="albedo_on_previous_timestep_assuming_deep_snow">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_ice_in_surface_snow">
@@ -2750,34 +2754,44 @@
       <standard_name name="molecular_sublayer_thickness_in_sea_water">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_diffuse_nir_over_ice">
+      <standard_name name="diffuse_nir_albedo_of_ice"
+                     long_name="ice surface albedo for diffuse near-infrared radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_diffuse_nir_over_land">
+      <standard_name name="diffuse_nir_albedo_of_land"
+                     long_name="land surface albedo for diffuse near-infrared radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_diffuse_visible_over_ice">
+      <standard_name name="diffuse_visible_albedo_of_ice"
+                     long_name="ice surface albedo for diffuse visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_diffuse_visible_over_land">
+      <standard_name name="diffuse_visible_albedo_of_land"
+                     long_name="land surface albedo for diffuse visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_direct_nir_over_ice">
+      <standard_name name="direct_nir_albedo_of_ice"
+                     long_name="ice surface albedo for direct near-infrared radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_direct_nir_over_land">
+      <standard_name name="direct_nir_albedo_of_land"
+                     long_name="land surface albedo for direct near-infrared radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_direct_visible_over_ice">
+      <standard_name name="direct_visible_albedo_of_ice"
+                     long_name="ice surface albedo for direct visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_albedo_direct_visible_over_land">
+      <standard_name name="direct_visible_albedo_of_land"
+                     long_name="land surface albedo for direct visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_diffused_shortwave_albedo_over_ice">
+      <standard_name name="diffuse_shortwave_albedo_of_ice"
+                     long_name="ice surface albedo for diffuse shortwave radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_diffused_shortwave_albedo_over_land">
+      <standard_name name="diffuse_shortwave_albedo_of_land"
+                     long_name="land surface albedo for diffuse shortwave radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="surface_drag_coefficient_for_heat_and_moisture_for_noahmp">
@@ -2845,7 +2859,8 @@
       <standard_name name="surface_snow_area_fraction_over_land">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_snow_free_albedo_over_land">
+      <standard_name name="albedo_of_land_assuming_no_snow_cover"
+                   long_name="surface snow-free albedo over land">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="lwe_surface_snow">
@@ -3102,10 +3117,12 @@
       <standard_name name="surface_net_downwelling_shortwave_flux_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_nir_albedo_diffuse_rad_for_coupling">
+      <standard_name name="diffuse_nir_albedo_for_coupling"
+                     long_name="surface albedo for diffuse near-infrared radiation for coupling">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_nir_albedo_direct_rad_for_coupling">
+      <standard_name name="direct_nir_albedo_for_coupling"
+                     long_name="surface albedo for direct near-infrared radiation for coupling">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="lwe_surface_snow_from_coupled_process">
@@ -3135,10 +3152,12 @@
       <standard_name name="surface_upwelling_longwave_flux_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_vis_albedo_diffuse_rad_for_coupling">
+      <standard_name name="diffuse_visible_albedo_for_coupling"
+                     long_name="surface albedo for diffuse visible radiation for coupling">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_vis_albedo_direct_rad_for_coupling">
+      <standard_name name="direct_visible_albedo_for_coupling"
+                     long_name="surface albedo for direct visible radiation for coupling">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="surface_x_momentum_flux_from_coupled_process">
@@ -3276,7 +3295,8 @@
       <standard_name name="surface_lw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep">
          <type kind="" units="W m-2">sfcflw_type</type>
       </standard_name>
-      <standard_name name="surface_albedo_for_diffused_shortwave_on_radiation_timestep">
+      <standard_name name="diffuse_shortwave_albedo_on_radiation_timestep"
+                     long_name="surface albedo for diffuse shortwave radiation on the timestep for radiation physics">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="surface_longwave_emissivity">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -1,4 +1,186 @@
 <standard_names name="CCPP Standard Name Library" version="1.0">
+  <section name="base_names"
+           comment="Base names are the 'elemental' quantities from which\n
+                    the more complex standard names are constructed.\n
+                    Base names can roughly be broken down into three categories:\n">
+    <section name="generic_names"
+             comment="The following names are too general to be chosen as\n
+                      standard names, but they can serve as base names for\n
+                      more specific standard names.\n">
+      <standard_name name="amount"
+                     long_name="amount">
+        <type units="kg m-2">real</type>
+      </standard_name>
+      <standard_name name="area"
+                     long_name="area">
+        <type units="m2">real</type>
+      </standard_name>
+      <standard_name name="area_fraction"
+                     long_name="area_fraction">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="binary_mask"
+                     long_name="binary_mask">
+        <type units="1">integer</type>
+      </standard_name>
+      <standard_name name="coefficient"
+                     long_name="coefficient">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="coefficient"
+                     long_name="coefficient">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="data_mask"
+                     long_name="data_mask">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="density"
+                     long_name="density">
+        <type units="kg m-3">real</type>
+      </standard_name>
+      <standard_name name="energy"
+                     long_name="energy">
+        <type units="J">real</type>
+      </standard_name>
+      <standard_name name="energy_content"
+                     long_name="energy_content">
+        <type units="J m-2">real</type>
+      </standard_name>
+      <standard_name name="energy_density"
+                     long_name="energy_density">
+        <type units="J m-3">real</type>
+      </standard_name>
+      <standard_name name="frequency"
+                     long_name="frequency">
+        <type units="s-1">real</type>
+      </standard_name>
+      <standard_name name="heat_flux"
+                     long_name="heat_flux">
+        <type units="W m-2">real</type>
+      </standard_name>
+      <standard_name name="heat_transport"
+                     long_name="heat_transport">
+        <type units="W">real</type>
+      </standard_name>
+      <standard_name name="mass"
+                     long_name="mass">
+        <type units="kg">real</type>
+      </standard_name>
+      <standard_name name="mass_flux"
+                     long_name="mass_flux">
+        <type units="kg m-2 s-1">real</type>
+      </standard_name>
+      <standard_name name="mass_fraction"
+                     long_name="mass_fraction">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="mixing_ratio"
+                     long_name="mixing_ratio">
+        <type units="kg kg-1">real</type>
+      </standard_name>
+      <standard_name name="mass_transport"
+                     long_name="mass_transport">
+        <type units="kg s-1">real</type>
+      </standard_name>
+      <standard_name name="mole_fraction"
+                     long_name="mole_fraction">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="mole_flux"
+                     long_name="mole_flux">
+        <type units="mol m-2 s-1">real</type>
+      </standard_name>
+      <standard_name name="momentum_flux"
+                     long_name="momentum_flux">
+        <type units="Pa">real</type>
+      </standard_name>
+      <standard_name name="partial_pressure"
+                     long_name="partial_pressure">
+        <type units="Pa">real</type>
+      </standard_name>
+      <standard_name name="period"
+                     long_name="period">
+        <type units="s">real</type>
+      </standard_name>
+      <standard_name name="power"
+                     long_name="power">
+        <type units="W">real</type>
+      </standard_name>
+      <standard_name name="pressure"
+                     long_name="pressure">
+        <type units="Pa">real</type>
+      </standard_name>
+      <standard_name name="probability"
+                     long_name="probability">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="radiative_flux"
+                     long_name="radiative_flux">
+        <type units="W m-2">real</type>
+      </standard_name>
+      <standard_name name="radius"
+                     long_name="radius">
+        <type units="m">real</type>
+      </standard_name>
+      <standard_name name="specific_eddy_kinetic_energy"
+                     long_name="specific_eddy_kinetic_energy">
+        <type units="m2 s-2">real</type>
+      </standard_name>
+      <standard_name name="speed"
+                     long_name="speed">
+        <type units="m s-1">real</type>
+      </standard_name>
+      <standard_name name="stress"
+                     long_name="stress">
+        <type units="Pa">real</type>
+      </standard_name>
+      <standard_name name="streamfunction"
+                     long_name="streamfunction">
+        <type units="m2 s-1">real</type>
+      </standard_name>
+      <standard_name name="temperature"
+                     long_name="temperature">
+        <type units="K">real</type>
+      </standard_name>
+      <standard_name name="thickness"
+                     long_name="thickness">
+        <type units="m">real</type>
+      </standard_name>
+      <standard_name name="velocity"
+                     long_name="velocity">
+        <type units="m s-1">real</type>
+      </standard_name>
+      <standard_name name="velocity_potential"
+                     long_name="velocity_potential">
+        <type units="m2 s-1">real</type>
+      </standard_name>
+      <standard_name name="volume"
+                     long_name="volume">
+        <type units="m3">real</type>
+      </standard_name>
+      <standard_name name="volume_flux"
+                     long_name="volume_flux">
+        <type units="m s-1">real</type>
+      </standard_name>
+      <standard_name name="volume_fraction"
+                     long_name="volume_fraction">
+        <type units="1">real</type>
+      </standard_name>
+      <standard_name name="volume_mixing_ratio"
+                     long_name="volume_mixing_ratio">
+        <type units="mol mol-1">real</type>
+      </standard_name>
+      <standard_name name="volume_transport"
+                     long_name="volume_transport">
+        <type units="m3 s-1">real</type>
+      </standard_name>
+      <standard_name name="vorticity"
+                     long_name="vorticity">
+        <type units="s-1">real</type>
+      </standard_name>
+    </section>
+  </section>
   <section name="dimensions"
            comment="Dimension standard names may come in sets of six
                     related standard names for each dimension:\n

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -180,7 +180,321 @@
         <type units="s-1">real</type>
       </standard_name>
     </section>
+    <section name="chemical_species"
+             comment="These are the base names for specific chemical species\n">
+      <standard_name name="c5h8"
+                     long_name="Isoprene">
+      </standard_name>
+      <standard_name name="co2"
+                     long_name="Carbon dioxide">
+      </standard_name>
+      <standard_name name="co"
+                     long_name="Carbon monoxide">
+      </standard_name>
+      <standard_name name="ccl4"
+                     long_name="Tetrachloromethane">
+      </standard_name>
+      <standard_name name="cfc11"
+                     long_name="Trichlorofluoromethane">
+      </standard_name>
+      <standard_name name="cfc12"
+                     long_name="Dichlorodifluoromethane">
+      </standard_name>
+      <standard_name name="cfc113"
+                     long_name="1,1,2-Trichloro-1,2,2-trifluoroethane">
+      </standard_name>
+      <standard_name name="cfc22"
+                     long_name="Chlorodifluoromethane">
+      </standard_name>
+      <standard_name name="dimethyl_sulfide"
+                     long_name="Dimethyl sulfide; DMS">
+      </standard_name>
+      <standard_name name="hcho"
+                     long_name="Formaldehyde">
+      </standard_name>
+      <standard_name name="hydrophilic_black_carbon"
+                     long_name="hydrophilic_black_carbon">
+      </standard_name>
+      <standard_name name="hydrophobic_black_carbon"
+                     long_name="hydrophobic_black_carbon">
+      </standard_name>
+      <standard_name name="hydrophilic_organic_carbon"
+                     long_name="hydrophilic_organic_carbon">
+      </standard_name>
+      <standard_name name="hydrophobic_organic_carbon"
+                     long_name="hydrophobic_organic_carbon">
+      </standard_name>
+      <standard_name name="methane"
+                     long_name="ch4">
+      </standard_name>
+      <standard_name name="n2o"
+                     long_name="Nitrous Oxide, N₂O">
+      </standard_name>
+      <standard_name name="nitrate"
+                     long_name="Chemical species containing the nitrate ion">
+      </standard_name>
+      <standard_name name="nitrite"
+                     long_name="Chemical species containing the nitrite ion">
+      </standard_name>
+      <standard_name name="no2"
+                     long_name="Nitrogen dioxide">
+      </standard_name>
+      <standard_name name="no"
+                     long_name="Nitric oxide NO (Nitrogen oxide, Nitrogen monoxide)">
+      </standard_name>
+      <standard_name name="oxygen"
+                     long_name="Molecular oxygen, O₂">
+      </standard_name>
+      <standard_name name="ozone"
+                     long_name="Ozone, O₃">
+      </standard_name>
+      <standard_name name="phosphate"
+                     long_name="Chemical species containing the phosphate ion">
+      </standard_name>
+      <standard_name name="silicate"
+                     long_name="Chemical species containing the silicate ion">
+      </standard_name>
+      <standard_name name="sulfate"
+                     long_name="Chemical species containing the sulfate ion">
+      </standard_name>
+      <standard_name name="sulfur_dioxide"
+                     long_name="so2">
+      </standard_name>
+    </section>
   </section>
+    <section name="base_standard_names"
+             comment="These names are used as bases for other names, but may\n
+                      also be considered standard names on their own. See the\n
+                      full list of standard names for further details.\n">
+      <standard_name name="absolute_vorticity"
+                     long_name="absolute_vorticity">
+      </standard_name>
+      <standard_name name="air_potential_temperature"
+                     long_name="air_potential_temperature">
+      </standard_name>
+      <standard_name name="air_pressure"
+                     long_name="air_pressure">
+      </standard_name>
+      <standard_name name="air_pressure_thickness"
+                     long_name="air_pressure_thickness">
+      </standard_name>
+      <standard_name name="air_temperature"
+                     long_name="air_temperature">
+      </standard_name>
+      <standard_name name="air_temperature/water_vapor"
+                     long_name="air_temperature/water_vapor">
+      </standard_name>
+      <standard_name name="albedo"
+                     long_name="albedo">
+      </standard_name>
+      <standard_name name="atmosphere_heat_diffusivity"
+                     long_name="atmosphere_heat_diffusivity">
+      </standard_name>
+      <standard_name name="cloud_area_fraction"
+                     long_name="cloud_area_fraction">
+      </standard_name>
+      <standard_name name="cloud_condensate"
+                     long_name="cloud_condensate">
+      </standard_name>
+      <standard_name name="cloud_ice"
+                     long_name="cloud_ice">
+      </standard_name>
+      <standard_name name="cloud_liquid_water"
+                     long_name="cloud_liquid_water">
+      </standard_name>
+      <standard_name name="date"
+                     long_name="date">
+      </standard_name>
+      <standard_name name="density"
+                     long_name="density">
+      </standard_name>
+      <standard_name name="diffuse_nir_albedo"
+                     long_name="diffuse_nir_albedo">
+      </standard_name>
+      <standard_name name="diffuse_nir_shortwave_flux"
+                     long_name="diffuse_nir_shortwave_flux">
+      </standard_name>
+      <standard_name name="diffuse_shortwave_albedo"
+                     long_name="diffuse_shortwave_albedo">
+      </standard_name>
+      <standard_name name="diffuse_uv_and_vis_shortwave_flux"
+                     long_name="diffuse_uv_and_vis_shortwave_flux">
+      </standard_name>
+      <standard_name name="diffuse_visible_albedo"
+                     long_name="diffuse_visible_albedo">
+      </standard_name>
+      <standard_name name="direct_nir_albedo"
+                     long_name="direct_nir_albedo">
+      </standard_name>
+      <standard_name name="direct_nir_shortwave_flux"
+                     long_name="direct_nir_shortwave_flux">
+      </standard_name>
+      <standard_name name="direct_uv_and_vis_shortwave_flux"
+                     long_name="direct_uv_and_vis_shortwave_flux">
+      </standard_name>
+      <standard_name name="direct_visible_albedo"
+                     long_name="direct_visible_albedo">
+      </standard_name>
+      <standard_name name="divergence"
+                     long_name="divergence">
+      </standard_name>
+      <standard_name name="dry_air_density"
+                     long_name="dry_air_density">
+      </standard_name>
+      <standard_name name="dry_air_enthalpy"
+                     long_name="dry_air_enthalpy">
+      </standard_name>
+      <standard_name name="exner_function"
+                     long_name="exner_function">
+      </standard_name>
+      <standard_name name="filename"
+                     long_name="filename">
+      </standard_name>
+      <standard_name name="forecast_time"
+                     long_name="forecast_time">
+      </standard_name>
+      <standard_name name="geopotential"
+                     long_name="geopotential">
+      </standard_name>
+      <standard_name name="geopotential_height"
+                     long_name="geopotential_height">
+      </standard_name>
+      <standard_name name="graupel"
+                     long_name="graupel">
+      </standard_name>
+      <standard_name name="gravitational_acceleration"
+                     long_name="gravitational_acceleration">
+      </standard_name>
+      <standard_name name="hail"
+                     long_name="hail">
+      </standard_name>
+      <standard_name name="heat_flux"
+                     long_name="heat_flux">
+      </standard_name>
+      <standard_name name="hygroscopic_aerosols"
+                     long_name="hygroscopic_aerosols">
+      </standard_name>
+      <standard_name name="ice"
+                     long_name="ice">
+      </standard_name>
+      <standard_name name="latent_heat_flux"
+                     long_name="latent_heat_flux">
+      </standard_name>
+      <standard_name name="liquid_water"
+                     long_name="liquid_water">
+      </standard_name>
+      <standard_name name="longwave_flux"
+                     long_name="longwave_flux">
+      </standard_name>
+      <standard_name name="momentum_flux"
+                     long_name="momentum_flux">
+      </standard_name>
+      <standard_name name="nonhygroscopic_ice_nucleating_aerosols"
+                     long_name="nonhygroscopic_ice_nucleating_aerosols">
+      </standard_name>
+      <standard_name name="ozone"
+                     long_name="ozone">
+      </standard_name>
+      <standard_name name="pressure"
+                     long_name="pressure">
+      </standard_name>
+      <standard_name name="rain"
+                     long_name="rain">
+      </standard_name>
+      <standard_name name="rain_water"
+                     long_name="rain_water">
+      </standard_name>
+      <standard_name name="random_number"
+                     long_name="random_number">
+      </standard_name>
+      <standard_name name="random_number_seed"
+                     long_name="random_number_seed">
+      </standard_name>
+      <standard_name name="reference_pressure"
+                     long_name="reference_pressure">
+      </standard_name>
+      <standard_name name="relative_humidity"
+                     long_name="relative_humidity">
+      </standard_name>
+      <standard_name name="roughness_length"
+                     long_name="roughness_length">
+      </standard_name>
+      <standard_name name="sensible_heat_flux"
+                     long_name="sensible_heat_flux">
+      </standard_name>
+      <standard_name name="shortwave_flux"
+                     long_name="shortwave_flux">
+      </standard_name>
+      <standard_name name="snow"
+                     long_name="snow">
+      </standard_name>
+      <standard_name name="snow_area_fraction"
+                     long_name="snow_area_fraction">
+      </standard_name>
+      <standard_name name="soil_moisture"
+                     long_name="soil_moisture">
+      </standard_name>
+      <standard_name name="soil_temperature"
+                     long_name="soil_temperature">
+      </standard_name>
+      <standard_name name="solar_declination_angle"
+                     long_name="solar_declination_angle">
+      </standard_name>
+      <standard_name name="solar_zenith_angle"
+                     long_name="solar_zenith_angle">
+      </standard_name>
+      <standard_name name="streamfunction"
+                     long_name="streamfunction">
+      </standard_name>
+      <standard_name name="surface_skin_temperature"
+                     long_name="surface_skin_temperature">
+      </standard_name>
+      <standard_name name="temperature"
+                     long_name="temperature">
+      </standard_name>
+      <standard_name name="temperature_flux"
+                     long_name="temperature_flux">
+      </standard_name>
+      <standard_name name="time"
+                     long_name="time">
+      </standard_name>
+      <standard_name name="total_energy"
+                     long_name="total_energy">
+      </standard_name>
+      <standard_name name="total_water"
+                     long_name="total_water">
+      </standard_name>
+      <standard_name name="tracer"
+                     long_name="tracer">
+      </standard_name>
+      <standard_name name="tracers"
+                     long_name="tracers">
+      </standard_name>
+      <standard_name name="turbulent_kinetic_energy"
+                     long_name="turbulent_kinetic_energy">
+      </standard_name>
+      <standard_name name="velocity_potential"
+                     long_name="velocity_potential">
+      </standard_name>
+      <standard_name name="virtual_potential_temperature"
+                     long_name="virtual_potential_temperature">
+      </standard_name>
+      <standard_name name="virtual_temperature"
+                     long_name="virtual_temperature">
+      </standard_name>
+      <standard_name name="water"
+                     long_name="water">
+      </standard_name>
+      <standard_name name="water_vapor"
+                     long_name="water_vapor">
+      </standard_name>
+      <standard_name name="wind"
+                     long_name="wind">
+      </standard_name>
+      <standard_name name="wind_speed"
+                     long_name="wind_speed">
+      </standard_name>
+    </section>
   <section name="dimensions"
            comment="Dimension standard names may come in sets of six
                     related standard names for each dimension:\n
@@ -819,7 +1133,7 @@
     <standard_name name="mole_fraction_of_ozone_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
-    <standard_name name="mole_fraction_of_carbon_dioxide_in_air">
+    <standard_name name="mole_fraction_of_co2_in_air">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ch4"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -224,7 +224,7 @@
                      long_name="ch4">
       </standard_name>
       <standard_name name="n2o"
-                     long_name="Nitrous Oxide, N₂O">
+                     long_name="Nitrous Oxide, N_2O">
       </standard_name>
       <standard_name name="nitrate"
                      long_name="Chemical species containing the nitrate ion">
@@ -239,10 +239,10 @@
                      long_name="Nitric oxide NO (Nitrogen oxide, Nitrogen monoxide)">
       </standard_name>
       <standard_name name="oxygen"
-                     long_name="Molecular oxygen, O₂">
+                     long_name="Molecular oxygen, O_2">
       </standard_name>
       <standard_name name="ozone"
-                     long_name="Ozone, O₃">
+                     long_name="Ozone, O_3">
       </standard_name>
       <standard_name name="phosphate"
                      long_name="Chemical species containing the phosphate ion">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -2857,7 +2857,7 @@
       <standard_name name="surface_friction_velocity_for_momentum">
          <type kind="kind_phys" units="m s-1">real</type>
       </standard_name>
-      <standard_name name="surface_upward_latent_heat_flux">
+      <standard_name name="upward_latent_heat_flux_at_surface">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="surface_longwave_emissivity_over_ice">
@@ -2988,52 +2988,52 @@
       <standard_name name="convective_cloud_condensate_after_rainout">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_downwelling_direct_nir_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_downwelling_longwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_net_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_net_downwelling_direct_nir_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_net_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_net_downwelling_longwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_net_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_upward_latent_heat_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_upward_latent_heat_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_upward_sensible_heat_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_upward_sensible_heat_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_x_momentum_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_x_momentum_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="Pa s">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_y_momentum_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_y_momentum_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="Pa s">real</type>
       </standard_name>
       <standard_name name="cellular_automata_area_fraction_for_deep_convection_from_coupled_process">
@@ -3049,58 +3049,58 @@
       <standard_name name="air_pressure_at_surface_for_coupling">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_diffuse_nir_shortwave_flux_for_coupling">
+      <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling">
+      <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_direct_nir_shortwave_flux_for_coupling">
+      <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling">
+      <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_longwave_flux_for_coupling">
+      <standard_name name="downwelling_longwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_shortwave_flux_for_coupling">
+      <standard_name name="downwelling_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_net_downwelling_diffuse_nir_shortwave_flux_for_coupling">
+      <standard_name name="net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling">
+      <standard_name name="net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_net_downwelling_direct_nir_shortwave_flux_for_coupling">
+      <standard_name name="net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_net_downwelling_direct_uv_and_vis_shortwave_flux_for_coupling">
+      <standard_name name="net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_net_downwelling_longwave_flux_for_coupling">
+      <standard_name name="net_downwelling_longwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_net_downwelling_shortwave_flux_for_coupling">
+      <standard_name name="net_downwelling_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="surface_skin_temperature_for_coupling">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="surface_upward_latent_heat_flux_for_coupling">
+      <standard_name name="upward_latent_heat_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upward_sensible_heat_flux_for_chemistry_coupling">
+      <standard_name name="upward_sensible_heat_flux_at_surface_for_chemistry_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upward_sensible_heat_flux_for_coupling">
+      <standard_name name="upward_sensible_heat_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_x_momentum_flux_for_coupling">
+      <standard_name name="x_momentum_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
-      <standard_name name="surface_y_momentum_flux_for_coupling">
+      <standard_name name="y_momentum_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
       <standard_name name="temperature_at_2m_for_coupling">
@@ -3140,25 +3140,25 @@
       <standard_name name="area_type_from_coupled_process">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_diffuse_nir_shortwave_flux_on_radiation_timestep">
+      <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_diffuse_uv_and_vis_shortwave_flux_on_radiation_timestep">
+      <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_direct_nir_shortwave_flux_on_radiation_timestep">
+      <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_direct_uv_and_vis_shortwave_flux_on_radiation_timestep">
+      <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_longwave_flux_on_radiation_timestep">
+      <standard_name name="downwelling_longwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_downwelling_shortwave_flux_on_radiation_timestep">
+      <standard_name name="downwelling_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_net_downwelling_shortwave_flux_on_radiation_timestep">
+      <standard_name name="net_downwelling_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="diffuse_nir_albedo_for_coupling"
@@ -3172,28 +3172,28 @@
       <standard_name name="lwe_surface_snow_from_coupled_process">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="surface_upward_latent_heat_flux_from_coupled_process">
+      <standard_name name="upward_latent_heat_flux_at_surface_from_coupled_process">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upward_sensible_heat_flux_from_coupled_process">
+      <standard_name name="upward_sensible_heat_flux_at_surface_from_coupled_process">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upwelling_diffuse_nir_shortwave_flux_on_radiation_timestep">
+      <standard_name name="upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upwelling_diffuse_uv_and_vis_shortwave_flux_on_radiation_timestep">
+      <standard_name name="upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upwelling_direct_nir_shortwave_flux_on_radiation_timestep">
+      <standard_name name="upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upwelling_direct_uv_and_vis_shortwave_flux_on_radiation_timestep">
+      <standard_name name="upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upwelling_longwave_flux_from_coupled_process">
+      <standard_name name="upwelling_longwave_flux_at_surface_from_coupled_process">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="surface_upwelling_longwave_flux_on_radiation_timestep">
+      <standard_name name="upwelling_longwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="diffuse_visible_albedo_for_coupling"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -261,7 +261,6 @@
                      long_name="so2">
       </standard_name>
     </section>
-  </section>
     <section name="base_standard_names"
              comment="These names are used as bases for other names, but may\n
                       also be considered standard names on their own. See the\n
@@ -495,6 +494,7 @@
                      long_name="wind_speed">
       </standard_name>
     </section>
+  </section>
   <section name="dimensions"
            comment="Dimension standard names may come in sets of six
                     related standard names for each dimension:\n

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -312,8 +312,8 @@
       <standard_name name="diffuse_uv_and_vis_shortwave_flux"
                      long_name="diffuse ultraviolet and visible shortwave flux">
       </standard_name>
-      <standard_name name="diffuse_visible_albedo"
-                     long_name="diffuse_visible_albedo">
+      <standard_name name="diffuse_vis_albedo"
+                     long_name="diffuse visible albedo">
       </standard_name>
       <standard_name name="direct_nir_albedo"
                      long_name="direct near-infrared albedo">
@@ -324,8 +324,8 @@
       <standard_name name="direct_uv_and_vis_shortwave_flux"
                      long_name="direct ultraviolet and visible shortwave flux">
       </standard_name>
-      <standard_name name="direct_visible_albedo"
-                     long_name="direct_visible_albedo">
+      <standard_name name="direct_vis_albedo"
+                     long_name="direct visible albedo">
       </standard_name>
       <standard_name name="divergence"
                      long_name="divergence">
@@ -3287,11 +3287,11 @@
                      long_name="land surface albedo for diffuse near-infrared radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="diffuse_visible_albedo_of_ice"
+      <standard_name name="diffuse_vis_albedo_of_ice"
                      long_name="ice surface albedo for diffuse visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="diffuse_visible_albedo_of_land"
+      <standard_name name="diffuse_vis_albedo_of_land"
                      long_name="land surface albedo for diffuse visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
@@ -3303,11 +3303,11 @@
                      long_name="land surface albedo for direct near-infrared radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="direct_visible_albedo_of_ice"
+      <standard_name name="direct_vis_albedo_of_ice"
                      long_name="ice surface albedo for direct visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="direct_visible_albedo_of_land"
+      <standard_name name="direct_vis_albedo_of_land"
                      long_name="land surface albedo for direct visible radiation">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
@@ -3706,11 +3706,11 @@
       <standard_name name="upwelling_longwave_flux_at_surface_on_radiation_timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="diffuse_visible_albedo_for_coupling"
+      <standard_name name="diffuse_vis_albedo_for_coupling"
                      long_name="surface albedo for diffuse visible radiation for coupling">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="direct_visible_albedo_for_coupling"
+      <standard_name name="direct_vis_albedo_for_coupling"
                      long_name="surface albedo for direct visible radiation for coupling">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -280,9 +280,6 @@
       <standard_name name="air_temperature"
                      long_name="air_temperature">
       </standard_name>
-      <standard_name name="air_temperature/water_vapor"
-                     long_name="air_temperature/water_vapor">
-      </standard_name>
       <standard_name name="albedo"
                      long_name="albedo">
       </standard_name>
@@ -308,28 +305,28 @@
                      long_name="density">
       </standard_name>
       <standard_name name="diffuse_nir_albedo"
-                     long_name="diffuse_nir_albedo">
+                     long_name="diffuse near-infrared albedo">
       </standard_name>
       <standard_name name="diffuse_nir_shortwave_flux"
-                     long_name="diffuse_nir_shortwave_flux">
+                     long_name="diffuse near-infrared shortwave flux">
       </standard_name>
       <standard_name name="diffuse_shortwave_albedo"
                      long_name="diffuse_shortwave_albedo">
       </standard_name>
       <standard_name name="diffuse_uv_and_vis_shortwave_flux"
-                     long_name="diffuse_uv_and_vis_shortwave_flux">
+                     long_name="diffuse ultraviolet and visible shortwave flux">
       </standard_name>
       <standard_name name="diffuse_visible_albedo"
                      long_name="diffuse_visible_albedo">
       </standard_name>
       <standard_name name="direct_nir_albedo"
-                     long_name="direct_nir_albedo">
+                     long_name="direct near-infrared albedo">
       </standard_name>
       <standard_name name="direct_nir_shortwave_flux"
-                     long_name="direct_nir_shortwave_flux">
+                     long_name="direct near-infrared shortwave flux">
       </standard_name>
       <standard_name name="direct_uv_and_vis_shortwave_flux"
-                     long_name="direct_uv_and_vis_shortwave_flux">
+                     long_name="direct ultraviolet and visible shortwave flux">
       </standard_name>
       <standard_name name="direct_visible_albedo"
                      long_name="direct_visible_albedo">
@@ -461,7 +458,7 @@
                      long_name="total_energy">
       </standard_name>
       <standard_name name="total_water"
-                     long_name="total_water">
+                     long_name="All water phases (solid, liquid, gas)">
       </standard_name>
       <standard_name name="tracer"
                      long_name="tracer">
@@ -480,9 +477,6 @@
       </standard_name>
       <standard_name name="virtual_temperature"
                      long_name="virtual_temperature">
-      </standard_name>
-      <standard_name name="water"
-                     long_name="water">
       </standard_name>
       <standard_name name="water_vapor"
                      long_name="water_vapor">
@@ -3484,16 +3478,20 @@
       <standard_name name="convective_cloud_condensate_after_rainout">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep">
@@ -3502,16 +3500,20 @@
       <standard_name name="cumulative_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative net downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative net downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
+                     long_name="cumulative net downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_net_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep">
@@ -3545,16 +3547,20 @@
       <standard_name name="air_pressure_at_surface_for_coupling">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
-      <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling"
+                     long_name="downwelling diffuse near-infrared shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling"
+                     long_name="downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_for_coupling"
+                     long_name="downwelling direct near-infrared shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling"
+                     long_name="downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_longwave_flux_at_surface_for_coupling">
@@ -3563,16 +3569,20 @@
       <standard_name name="downwelling_shortwave_flux_at_surface_for_coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling"
+                     long_name="net downwelling diffuse near-infrared shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling"
+                     long_name="net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling"
+                     long_name="net downwelling direct near-infrared shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling">
+      <standard_name name="net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling"
+                     long_name="downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_longwave_flux_at_surface_for_coupling">
@@ -3636,16 +3646,20 @@
       <standard_name name="area_type_from_coupled_process">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="downwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="downwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="downwelling direct near-infrared shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="downwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_longwave_flux_at_surface_on_radiation_timestep">
@@ -3674,16 +3688,20 @@
       <standard_name name="upward_sensible_heat_flux_at_surface_from_coupled_process">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="upwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="upwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="upwelling direct near-infrared shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
-      <standard_name name="upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep">
+      <standard_name name="upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
+                     long_name="upwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
          <type kind="kind_phys" units="W m-2">real</type>
       </standard_name>
       <standard_name name="upwelling_longwave_flux_at_surface_from_coupled_process">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -161,7 +161,7 @@
     <standard_name name="surface_pressure_of_dry_air">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="surface_geopotential">
+    <standard_name name="geopotential_at_surface">
       <type kind="kind_phys" units="m2 s-2">real</type>
     </standard_name>
     <standard_name name="air_temperature">
@@ -252,7 +252,7 @@
     <standard_name name="ln_air_pressure_of_dry_air">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
-    <standard_name name="reciprocal_of_exner_function_wrt_surface_air_pressure"
+    <standard_name name="reciprocal_of_exner_function_wrt_air_pressure_at_surface"
                    long_name="inverse exner function w.r.t. surface pressure, (ps/p)^(R/cp)">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
@@ -368,23 +368,23 @@
                    long_name="Total change in northward wind from a physics suite">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
-    <standard_name name="air_horizontal_streamfunction"
+    <standard_name name="horizontal_streamfunction_of_air"
                    long_name="Scalar function describing the streamlines of the horizontal wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
-    <standard_name name="air_horizontal_velocity_potential"
+    <standard_name name="horizontal_velocity_potential_of_air"
                    long_name="Scalar potential of the horizontal wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
-    <standard_name name="air_upward_absolute_vorticity"
+    <standard_name name="upward_absolute_vorticity_of_air"
                    long_name="The upward (kth) component of the curl of the vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
-    <standard_name name="air_horizontal_divergence"
+    <standard_name name="horizontal_divergence_of_air"
                    long_name="The (horizontal) divergence of the 2-D vector wind field">
       <type kind="kind_phys" units="s-1">real</type>
     </standard_name>
-    <standard_name name="surface_upward_heat_flux_in_air">
+    <standard_name name="upward_heat_flux_in_air_at_surface">
       <type kind="kind_phys" units="W m-2">real</type>
     </standard_name>
     <standard_name name="cumulative_boundary_flux_of_total_energy">
@@ -405,7 +405,7 @@
                    long_name="reference pressure in atmosphere layer">
       <type kind="kind_phys" units="Pa">real</type>
     </standard_name>
-    <standard_name name="reference_air_pressure_normalized_by_surface_air_pressure"
+    <standard_name name="reference_air_pressure_normalized_by_air_pressure_at_surface"
                    long_name="reference pressure normalized by surface pressure">
       <type kind="kind_phys" units="1">real</type>
     </standard_name>
@@ -491,7 +491,7 @@
                    long_name="content per unit area of water in top layer of soil">
       <type kind="kind_phys" units="kg m-2">real</type>
     </standard_name>
-    <standard_name name="surface_snow_density">
+    <standard_name name="density_of_snow_at_surface">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
     <standard_name name="urban_area_fraction_of_cell_area"
@@ -1702,10 +1702,10 @@
       <standard_name name="control_for_stochastic_land_surface_perturbation">
          <type kind="" units="1">integer</type>
       </standard_name>
-      <standard_name name="index_of_surface_air_pressure_on_previous_timestep_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_air_pressure_at_surface_on_previous_timestep_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_surface_air_pressure_two_timesteps_back_in_xyz_dimensioned_tracer_array">
+      <standard_name name="index_of_air_pressure_at_surface_two_timesteps_back_in_xyz_dimensioned_tracer_array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convectionin_in_xy_dimensioned_restart_array">
@@ -2312,7 +2312,7 @@
       <standard_name name="upward_virtual_potential_temperature_flux">
          <type kind="kind_phys" units="K m s-1">real</type>
       </standard_name>
-      <standard_name name="surface_upward_specific_humidity_flux_for_mellor_yamada_janjic_surface_layer_scheme">
+      <standard_name name="upward_specific_humidity_flux_at_surface_for_mellor_yamada_janjic_surface_layer_scheme">
          <type kind="kind_phys" units="m s-1 kg kg-1">real</type>
       </standard_name>
       <standard_name name="cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls">
@@ -2375,10 +2375,10 @@
       <standard_name name="subgrid_scale_cloud_fraction_from_shoc">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_air_pressure_on_previous_timestep">
+      <standard_name name="air_pressure_at_surface_on_previous_timestep">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
-      <standard_name name="surface_air_pressure_two_timesteps_back">
+      <standard_name name="air_pressure_at_surface_two_timesteps_back">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
       <standard_name name="control_for_surface_layer_evaporation">
@@ -2546,10 +2546,10 @@
       <standard_name name="temperature_in_ice_layer">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="surface_upward_specific_humidity_flux">
+      <standard_name name="upward_specific_humidity_flux_at_surface">
          <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
       </standard_name>
-      <standard_name name="surface_upward_temperature_flux">
+      <standard_name name="upward_temperature_flux_at_surface">
          <type kind="kind_phys" units="K m s-1">real</type>
       </standard_name>
       <standard_name name="lake_area_fraction">
@@ -2730,10 +2730,10 @@
                      long_name="mixing ratio of the mass of water vapor to the mass of moist air and hydrometeors, at two meters above surface">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="specified_surface_upward_specific_humidity_flux">
+      <standard_name name="specified_upward_specific_humidity_flux_at_surface">
          <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
       </standard_name>
-      <standard_name name="specified_surface_upward_temperature_flux">
+      <standard_name name="specified_upward_temperature_flux_at_surface">
          <type kind="kind_phys" units="K m s-1">real</type>
       </standard_name>
       <standard_name name="standard_deviation_of_subgrid_orography">
@@ -2853,10 +2853,10 @@
       <standard_name name="surface_skin_temperature_over_land">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="surface_snow_area_fraction_over_ice">
+      <standard_name name="snow_area_fraction_at_surface_over_ice">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_snow_area_fraction_over_land">
+      <standard_name name="snow_area_fraction_at_surface_over_land">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
       <standard_name name="albedo_of_land_assuming_no_snow_cover"
@@ -3003,7 +3003,7 @@
       <standard_name name="specific_humidity_at_2m_for_coupling">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="surface_air_pressure_for_coupling">
+      <standard_name name="air_pressure_at_surface_for_coupling">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
       <standard_name name="surface_downwelling_diffuse_nir_shortwave_flux_for_coupling">
@@ -3160,10 +3160,10 @@
                      long_name="surface albedo for direct visible radiation for coupling">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="surface_x_momentum_flux_from_coupled_process">
+      <standard_name name="x_momentum_flux_at_surface_from_coupled_process">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
-      <standard_name name="surface_y_momentum_flux_from_coupled_process">
+      <standard_name name="y_momentum_flux_at_surface_from_coupled_process">
          <type kind="kind_phys" units="Pa">real</type>
       </standard_name>
       <standard_name name="tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -619,11 +619,11 @@
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation"
-                   long_name="saturated water vapor mixing ratio with respect to moist air and condensed water">
+                   long_name="saturated water vapor mass mixing ratio with respect to moist air and condensed water">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces_assuming_saturation"
-                   long_name="saturated water vapor mixing ratio with respect to moist air and condensed water at all interfaces excluding surface">
+                   long_name="saturated water vapor mass mixing ratio with respect to moist air and condensed water at all interfaces excluding surface">
       <type kind="kind_phys" units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature"
@@ -1633,7 +1633,8 @@
       <standard_name name="index_of_convective_cloud_area_fraction_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_convective_cloud_condensate_mixing_ratio_wrt_moist_air_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_convective_cloud_condensate_mixing_ratio_wrt_moist_air_in_xyz_dimensioned_restart_array"
+                   long_name="Index of convective cloud condensate mass mixing ratio with respect to moist air in the XYZ-dimensioned restart array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_horizontal_gridpoint_for_debug_output">
@@ -1642,7 +1643,8 @@
       <standard_name name="index_of_first_chemical_tracer_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_graupel_mixing_ratio_wrt_moist_air_in_tracer_concentration_array">
+      <standard_name name="index_of_graupel_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
+                   long_name="Index of graupel mass mixing ratio with respect to moist air in the tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_graupel_effective_radius_in_xyz_dimensioned_restart_array">
@@ -1651,7 +1653,8 @@
       <standard_name name="index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_cloud_ice_mixing_ratio_wrt_moist_air_in_tracer_concentration_array">
+      <standard_name name="index_of_cloud_ice_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
+                   long_name="Index of cloud ice mass mixing ratio with respect to moist air in the tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array">
@@ -1663,7 +1666,8 @@
       <standard_name name="index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_in_tracer_concentration_array">
+      <standard_name name="index_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
+                   long_name="Index of liquid water mass mixing ratio with respect to moist air in the tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array">
@@ -1672,7 +1676,8 @@
       <standard_name name="index_of_mass_weighted_rime_factor_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_ozone_mixing_ratio_wrt_moist_air_in_tracer_concentration_array">
+      <standard_name name="index_of_ozone_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
+                   long_name="Index of ozone mass mixing ratio with respect to moist air in the tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_rain_effective_radius_in_xyz_dimensioned_restart_array">
@@ -1681,7 +1686,8 @@
       <standard_name name="index_of_mass_number_concentration_of_rain_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_rain_mixing_ratio_wrt_moist_air_in_tracer_concentration_array">
+      <standard_name name="index_of_rain_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
+                   long_name="Index of rain mass mixing ratio with respect to moist air in the tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_snow_effective_radius_in_xyz_dimensioned_restart_array">
@@ -1690,15 +1696,16 @@
       <standard_name name="index_of_mass_number_concentration_of_snow_in_tracer_concentration_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array">
+      <standard_name name="index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
+                   long_name="Index of snow mass mixing ratio with respect to moist air in the tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array"
-                   long_name="Index of specific humidity (qv) on previous timestep in xyz dimensioned restart array">
+                   long_name="Index of specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in xyz dimensioned restart array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back_in_xyz_dimensioned_restart_array"
-                   long_name="Index of specific humidity (qv) two timesteps back in xyz dimensioned restart array">
+                   long_name="Index of specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back in xyz dimensioned restart array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="control_for_stochastic_land_surface_perturbation">
@@ -1720,7 +1727,7 @@
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
-                   long_name="Index of specific humidity (qv) in tracer concentration array">
+                   long_name="Index of specific humidity (water vapor mass mixing ratio with respect to moist air) in tracer concentration array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array">
@@ -1825,13 +1832,16 @@
       <standard_name name="prescribed_number_concentration_of_cloud_ice">
          <type kind="kind_phys" units="m-3">real</type>
       </standard_name>
-      <standard_name name="minimum_cloud_condensate_mixing_ratio_wrt_moist_air_threshold">
+      <standard_name name="minimum_cloud_condensate_mixing_ratio_wrt_moist_air_threshold"
+                   long_name="Minimum threshold cloud condensate mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="minimum_cloud_liquid_water_mixing_ratio_wrt_moist_air_threshold">
+      <standard_name name="minimum_cloud_liquid_water_mixing_ratio_wrt_moist_air_threshold"
+                   long_name="Minimum threshold cloud liquid water mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="minimum_cloud_ice_mixing_ratio_wrt_moist_air_threshold">
+      <standard_name name="minimum_cloud_ice_mixing_ratio_wrt_moist_air_threshold"
+                   long_name="Minimum threshold cloud ice mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="relative_humidity_threshold_for_ice_nucleation">
@@ -2190,10 +2200,12 @@
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_interstitial_type">
-      <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_interstitial">
+      <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_interstitial"
+                   long_name="Cloud ice mass mixing ratio with respect to moist air in interstitial scheme">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_interstitial">
+      <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_interstitial"
+                   long_name="Cloud liquid water mass mixing ratio with respect to moist air in interstitial scheme">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="radiatively_active_gases">
@@ -2205,10 +2217,12 @@
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_liquid_water_particles_in_air">
          <type kind="kind_phys" units="kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="process_split_cumulative_tendency_of_graupel_mixing_ratio_wrt_moist_air">
+      <standard_name name="process_split_cumulative_tendency_of_graupel_mixing_ratio_wrt_moist_air"
+                   long_name="Process-split cumulative tendency of the graupel mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="process_split_cumulative_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air">
+      <standard_name name="process_split_cumulative_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air"
+                   long_name="Process-split cumulative tendency of the cloud ice mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols">
@@ -2217,16 +2231,20 @@
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_air">
          <type kind="kind_phys" units="kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air">
+      <standard_name name="process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air"
+                   long_name="Process-split cumulative tendency of the cloud liquid water mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="process_split_cumulative_tendency_of_ozone_mixing_ratio_wrt_moist_air">
+      <standard_name name="process_split_cumulative_tendency_of_ozone_mixing_ratio_wrt_moist_air"
+                   long_name="Process-split cumulative tendency of the ozone mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="process_split_cumulative_tendency_of_rain_mixing_ratio_wrt_moist_air">
+      <standard_name name="process_split_cumulative_tendency_of_rain_mixing_ratio_wrt_moist_air"
+                   long_name="Process-split cumulative tendency of the rain mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="process_split_cumulative_tendency_of_snow_mixing_ratio_wrt_moist_air">
+      <standard_name name="process_split_cumulative_tendency_of_snow_mixing_ratio_wrt_moist_air"
+                   long_name="Process-split cumulative tendency of the snow mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_tracers">
@@ -2239,7 +2257,7 @@
          <type kind="kind_phys" units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_water_vapor_mixing_ratio_wrt_moist_air"
-                   long_name="Process-split cumulative tendency of specific humidity (qv)">
+                   long_name="Process-split cumulative tendency of specific humidity (water vapor mass mixing ratio with respect to moist air)">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_x_wind">
@@ -2286,7 +2304,8 @@
       <standard_name name="convective_cloud_area_fraction">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="convective_cloud_condensate_mixing_ratio_wrt_moist_air">
+      <standard_name name="convective_cloud_condensate_mixing_ratio_wrt_moist_air"
+                   long_name="Convective cloud condensate mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_graupel_particle">
@@ -2317,7 +2336,7 @@
          <type kind="kind_phys" units="K m s-1">real</type>
       </standard_name>
       <standard_name name="upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_mellor_yamada_janjic_surface_layer_scheme"
-                   long_name="Upward flux of specific humidity (qv) at surface for MYJ surface layer scheme">
+                   long_name="Upward flux of specific humidity (water vapor mass mixing ratio with respect to moist air) at surface for MYJ surface layer scheme">
          <type kind="kind_phys" units="m s-1 kg kg-1">real</type>
       </standard_name>
       <standard_name name="cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls">
@@ -2333,11 +2352,11 @@
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep"
-                   long_name="Specific humidity (qv) on previous timestep">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_nonphysics"
-                   long_name="Tendency of specific humidity (qv) due to nonphysics">
+                   long_name="Tendency of specific humidity (water vapor mass mixing ratio with respect to moist air) due to nonphysics">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="momentum_exchange_coefficient_for_myj_schemes">
@@ -2350,7 +2369,7 @@
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
       <standard_name name="variance_of_water_vapor_mixing_ratio_wrt_moist_air"
-                   long_name="Variance of specific humidity (qv)">
+                   long_name="Variance of specific humidity (water vapor mass mixing ratio with respect to moist air)">
          <type kind="kind_phys" units="kg2 kg-2">real</type>
       </standard_name>
       <standard_name name="random_number">
@@ -2365,8 +2384,8 @@
       <standard_name name="cumulative_min_vertical_index_at_cloud_base_between_sw_radiation_calls">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer">
-                   long_name="Specific humidity (qv) at the top of the viscous sublayer">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer"
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="stability_function_for_heat">
@@ -2375,10 +2394,12 @@
       <standard_name name="subgrid_scale_cloud_area_fraction_in_atmosphere_layer">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="subgrid_scale_cloud_ice_mixing_ratio_wrt_moist_air">
+      <standard_name name="subgrid_scale_cloud_ice_mixing_ratio_wrt_moist_air"
+                   long_name="Subgrid-scale cloud ice mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="subgrid_scale_cloud_liquid_water_mixing_ratio_wrt_moist_air">
+      <standard_name name="subgrid_scale_cloud_liquid_water_mixing_ratio_wrt_moist_air"
+                   long_name="Subgrid-scale cloud liquid water mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="subgrid_scale_cloud_fraction_from_shoc">
@@ -2394,14 +2415,14 @@
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_schemes"
-                   long_name="Surface specific humidity (qv) for MYJ schemes">
+                   long_name="Surface specific humidity (water vapor mass mixing ratio with respect to moist air) for MYJ schemes">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convection">
          <type kind="kind_phys" units="m s-1">real</type>
       </standard_name>
       <standard_name name="covariance_of_air_temperature_and_water_vapor_mixing_ratio_wrt_moist_air"
-                   long_name="Covariance of air temperature and specific humidity (qv)">
+                   long_name="Covariance of air temperature and specific humidity (water vapor mass mixing ratio with respect to moist air)">
          <type kind="kind_phys" units="K kg kg-1">real</type>
       </standard_name>
       <standard_name name="variance_of_air_temperature">
@@ -2432,11 +2453,11 @@
          <type kind="kind_phys" units="m s-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array"
-                   long_name="Specific humidity (qv) on previous timestep in XYZ-dimensioned restart array">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in XYZ-dimensioned restart array">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back"
-                   long_name="Specific humidity (qv) two timesteps back">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="weight_for_momentum_at_top_of_viscous_sublayer">
@@ -2446,7 +2467,7 @@
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="weight_for_water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer"
-                   long_name="Weight for specific humidity (qv) at the top of the viscous sublayer">
+                   long_name="Weight for specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
    </section>
@@ -2476,10 +2497,12 @@
       <standard_name name="canopy_water_amount">
          <type kind="kind_phys" units="kg m-2">real</type>
       </standard_name>
-      <standard_name name="cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_ice">
+      <standard_name name="cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_ice"
+                   long_name="Cloud condensed water mass mixing ratio with respect to moist air at surface over ice">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land">
+      <standard_name name="cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land"
+                   long_name="Cloud condensed water mass mixing ratio with respect to moist air at surface over land">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="coefficient_c_0">
@@ -2561,7 +2584,7 @@
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
       <standard_name name="upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface">
-                   long_name="Upward specific humidity (qv) flux at surface">
+                   long_name="Upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface">
          <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
       </standard_name>
       <standard_name name="upward_temperature_flux_at_surface">
@@ -2738,7 +2761,7 @@
          <type kind="kind_phys" units="m3 m-3">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_2m"
-                     long_name="Specific humidity (qv) at two meters above surface"> 
+                     long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) at two meters above surface"> 
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m"
@@ -2746,7 +2769,7 @@
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface"
-                   long_name="Specified upward specific humidity (qv) flux at surface"> 
+                   long_name="Specified upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface"> 
          <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
       </standard_name>
       <standard_name name="specified_upward_temperature_flux_at_surface">
@@ -2883,7 +2906,7 @@
          <type kind="kind_phys" units="mm">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface"
-                   long_name="Specific humidity (qv) at surface">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="ratio_of_height_to_monin_obukhov_length">
@@ -2946,10 +2969,12 @@
       <standard_name name="water_table_recharge_assuming_shallow">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_ice">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_ice"
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over ice">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
-      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_land">
+      <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_land"
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over land">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="wood_mass_content">
@@ -3018,7 +3043,7 @@
          <type kind="kind_phys" units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_2m_for_coupling"
-                   long_name="Specific humidity (qv) at 2 meters above surface used for coupling">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) at 2 meters above surface used for coupling">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="air_pressure_at_surface_for_coupling">
@@ -3082,7 +3107,7 @@
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
       <standard_name name="tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_moist_convection_for_coupling">
-                   long_name="Tendency of specific humidity (qv) due to moist convection used for coupling">
+                   long_name="Tendency of specific humidity (water vapor mass mixing ratio with respect to moist air) due to moist convection used for coupling">
          <type kind="kind_phys" units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="x_wind_at_10m_for_coupling">
@@ -3223,7 +3248,8 @@
       <standard_name name="air_temperature_at_surface_adjacent_layer">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer">
+      <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer"
+                   long_name="Cloud liquid water mass mixing ratio with respect to moist air at surface-adjacent layer">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air">
@@ -3250,7 +3276,8 @@
       <standard_name name="geopotential_at_interfaces">
          <type kind="kind_phys" units="m2 s-2">real</type>
       </standard_name>
-      <standard_name name="graupel_mixing_ratio_wrt_moist_air">
+      <standard_name name="graupel_mixing_ratio_wrt_moist_air"
+                   long_name="Graupel mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_graupel_in_air">
@@ -3262,7 +3289,8 @@
       <standard_name name="mass_number_concentration_of_cloud_ice_water_crystals_in_air">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="ozone_mixing_ratio_wrt_moist_air">
+      <standard_name name="ozone_mixing_ratio_wrt_moist_air"
+                   long_name="Ozone mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_rain_water_in_air">
@@ -3271,7 +3299,8 @@
       <standard_name name="mass_number_concentration_of_snow_in_air">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="snow_mixing_ratio_wrt_moist_air">
+      <standard_name name="snow_mixing_ratio_wrt_moist_air"
+                   long_name="Snow mass mixing ratio with respect to moist air">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="tracer_concentration">
@@ -3284,7 +3313,7 @@
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer"
-                   long_name="Specific humidity (qv) at surface-adjacent layer">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface-adjacent layer">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="x_wind_at_surface_adjacent_layer">
@@ -3428,7 +3457,8 @@
       <standard_name name="air_temperature_of_new_state">
          <type kind="kind_phys" units="K">real</type>
       </standard_name>
-      <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state">
+      <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state"
+                   long_name="Cloud liquid water mass mixing ratio with respect to moist air of new state">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state">
@@ -3437,7 +3467,8 @@
       <standard_name name="nonconvective_cloud_area_fraction_in_atmosphere_layer_of_new_state">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="graupel_mixing_ratio_wrt_moist_air_of_new_state">
+      <standard_name name="graupel_mixing_ratio_wrt_moist_air_of_new_state"
+                   long_name="Graupel mass mixing ratio with respect to moist air of new state">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_graupel_of_new_state">
@@ -3449,7 +3480,8 @@
       <standard_name name="mass_number_concentration_of_cloud_ice_water_crystals_in_air_of_new_state">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_of_new_state">
+      <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_of_new_state"
+                   long_name="Cloud ice mass mixing ratio with respect to moist air of new state">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_weighted_rime_factor_of_new_state">
@@ -3461,13 +3493,15 @@
       <standard_name name="mass_number_concentration_of_rain_of_new_state">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="rain_mixing_ratio_wrt_moist_air_of_new_state">
+      <standard_name name="rain_mixing_ratio_wrt_moist_air_of_new_state"
+                   long_name="Rain mass mixing ratio with respect to moist air of new state">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_snow_of_new_state">
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
-      <standard_name name="snow_mixing_ratio_wrt_moist_air_of_new_state">
+      <standard_name name="snow_mixing_ratio_wrt_moist_air_of_new_state"
+                   long_name="Snow mass mixing ratio with respect to moist air of new state">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="tracer_concentration_of_new_state">
@@ -3477,11 +3511,11 @@
          <type kind="kind_phys" units="kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_of_new_state_at_surface_adjacent_layer"
-                   long_name="Specific humidity (qv) of new state at surface-adjacent layer">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state at surface-adjacent layer">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_of_new_state"
-                   long_name="Specific humidity (qv) of new state">
+                   long_name="Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="x_wind_of_new_state_at_surface_adjacent_layer">

--- a/tools/write_standard_name_table.py
+++ b/tools/write_standard_name_table.py
@@ -129,7 +129,7 @@ def parse_command_line(args, description):
 def convert_xml_to_markdown(root, library_name, snl):
 ###############################################################################
     snl.write('# {}\n'.format(library_name))
-    # Write a table of contents
+    # Write a table of contents for top-level sections
     snl.write('#### Table of Contents\n')
     for section in root:
         sec_name = section.get('name')
@@ -138,15 +138,19 @@ def convert_xml_to_markdown(root, library_name, snl):
     # end for
     snl.write('\n')
     for section in root:
+        parse_section(snl, section)
+
+###############################################################################
+def parse_section(snl, sec, level='##'):
+###############################################################################
         # Step through the sections
-        sec_name = section.get('name')
-        sec_comment = section.get('comment')
-        snl.write('## {}\n'.format(sec_name))
+        sec_name = sec.get('name')
+        sec_comment = sec.get('comment')
+        snl.write(f'{level} {sec_name}\n')
         if sec_comment is not None:
             # First, squeeze out the spacing
             while sec_comment.find('  ') >= 0:
                 sec_comment = sec_comment.replace('  ', ' ')
-            # end while
             while sec_comment:
                 sec_comment = sec_comment.lstrip()
                 cind = sec_comment.find('\\n')
@@ -156,10 +160,10 @@ def convert_xml_to_markdown(root, library_name, snl):
                 else:
                     snl.write('{}\n'.format(sec_comment))
                     sec_comment = ''
-                # end if
-            # end while
-        # end if
-        for std_name in section:
+        for std_name in sec:
+            if std_name.tag == 'section':
+                parse_section(snl, std_name, level + '#')
+                continue
             stdn_name = std_name.get('name')
             stdn_longname = std_name.get('long_name')
             if stdn_longname is None:
@@ -183,10 +187,6 @@ def convert_xml_to_markdown(root, library_name, snl):
                 else:
                     emsg = "Unknown standard name property, '{}'"
                     raise ValueError(emsg.format(item.tag))
-                # end if
-            # end for
-        # end for
-    # end for
 
 ###############################################################################
 def main_func():


### PR DESCRIPTION
This is the second round of proposed rules changes based on our ongoing discussion to make both rules and names as consistent as possible. Major updates include:

### Standard Names
 - New "base_names" section, with subsections
 - Convert instances of "surface_X" to "X_at_surface"
 - Convert some instances of "air_X" or "X_of_air"
 - Explicitly state what mass mixing ratios are with respect to in long_name
 - Convert "mixing_ratio" to "water_vapor_mixing_ratio_wrt_moist_air"
 - Convert "surface_albedo" to simply "albedo", "surface_roughness_length" to simply "roughness_length"

### Rules
 - Update construction template to include [non-instant time] and [non-current time], swap [at level] and [in medium]
 - More detailed description of transformations and how they can work on multiple base names
 - Add a few more transformations

### `write_standard_name_table.py`
 - Updated to allow sub-sections in the standard names list

You can see these changes in the form of a Google doc for better visualization here: https://docs.google.com/document/d/19ysUCWDhv53W8fQbElW7opr_1Pm7ck95QRUyKM_qy4E/edit?tab=t.0 

Note: with this update, we have 347 standard names that are fully compliant with the rules we have set out. A big portion of the remainder are "flag"-type variables, indices, etc, which are not fully accounted for in the rules yet.