### PR TITLE
Cherry-picked from V1 branch: fix misspellings in Standard Names

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -229,9 +229,9 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
-* `air_horizontal_streamfunction`: Scalar function describing the streamlines of the horizontal wind
+* `air_horizontal_streamfunction`: Scalar function describing the stream lines of the wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `air_horizontal_velocity_potential`: Scalar potential of the horizontal wind
+* `air_horizontal_velocity_potential`: Scalar potential of the wind
     * `real(kind=kind_phys)`: units = m2 s-1
 * `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the vector wind field
     * `real(kind=kind_phys)`: units = s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -86,7 +86,7 @@ Currently, the only dimension which supports all six dimension types is horizont
     * `real(kind=kind_phys)`: units = kg m-3
 * `ratio_of_water_vapor_to_dry_air_gas_constants_minus_one`: (Rwv / Rdair) - 1.0
     * `real(kind=kind_phys)`: units = 1
-* `standard_gravitational_acceleration`: scalar constant representing gravitiational acceleration
+* `standard_gravitational_acceleration`: scalar constant representing gravitational acceleration
     * `real(kind=kind_phys)`: units = m s-2
 ## coordinates
 * `latitude`: Latitude
@@ -229,9 +229,9 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Total change in northward wind from a physics suite
     * `real(kind=kind_phys)`: units = m s-2
-* `air_horizontal_streamfunction`: Scalar function describing the stream lines of the wind
+* `air_horizontal_streamfunction`: Scalar function describing the streamlines of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
-* `air_horizontal_velocity_potential`: Scalar potential of the wind
+* `air_horizontal_velocity_potential`: Scalar potential of the horizontal wind
     * `real(kind=kind_phys)`: units = m2 s-1
 * `air_upward_absolute_vorticity`: The upward (kth) component of the curl of the vector wind field
     * `real(kind=kind_phys)`: units = s-1
@@ -546,7 +546,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `aerosol_aware_multiplicative_rain_conversion_parameter_for_shallow_convection`: Aerosol aware multiplicative rain conversion parameter for shallow convection
     * `real(kind=kind_phys)`: units = 1
-* `number_of_microphysics_varaibles_in_xy_dimensioned_restart_array`: Number of microphysics varaibles in xy dimensioned restart array
+* `number_of_microphysics_variables_in_xy_dimensioned_restart_array`: Number of microphysics variables in xy dimensioned restart array
     * `integer(kind=)`: units = count
 * `number_of_microphysics_variables_in_xyz_dimensioned_restart_array`: Number of microphysics variables in xyz dimensioned restart array
     * `integer(kind=)`: units = count
@@ -740,7 +740,7 @@ Variables related to the compute environment
     * `integer(kind=)`: units = 1
 * `control_for_land_surface_scheme_dynamic_vegetation`: Control for land surface scheme dynamic vegetation
     * `integer(kind=)`: units = 1
-* `indentifier_for_exponential_cloud_overlap_method`: Indentifier for exponential cloud overlap method
+* `identifier_for_exponential_cloud_overlap_method`: Identifier for exponential cloud overlap method
     * `integer(kind=)`: units = 1
 * `identifier_for_exponential_random_cloud_overlap_method`: Identifier for exponential random cloud overlap method
     * `integer(kind=)`: units = 1
@@ -906,7 +906,7 @@ Variables related to the compute environment
     * `integer(kind=)`: units = 1
 * `control_for_land_surface_scheme_runoff_and_groundwater`: Control for land surface scheme runoff and groundwater
     * `integer(kind=)`: units = 1
-* `identifer_for_scale_aware_mass_flux_deep_convection`: Identifer for scale aware mass flux deep convection
+* `identifier_for_scale_aware_mass_flux_deep_convection`: Identifier for scale aware mass flux deep convection
     * `integer(kind=)`: units = 1
 * `identifier_for_scale_aware_mass_flux_shallow_convection`: Identifier for scale aware mass flux shallow convection
     * `integer(kind=)`: units = 1
@@ -1126,7 +1126,7 @@ Variables related to the compute environment
     * `integer(kind=)`: units = index
 * `index_of_upward_virtual_potential_temperature_flux_in_xyz_dimensioned_restart_array`: Index of upward virtual potential temperature flux in xyz dimensioned restart array
     * `integer(kind=)`: units = index
-* `index_of_subgrid_cloud_area_fracation_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of subgrid cloud area fracation in atmosphere layer in xyz dimensioned restart array
+* `index_of_subgrid_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of subgrid cloud area fraction in atmosphere layer in xyz dimensioned restart array
     * `integer(kind=)`: units = index
 * `index_of_timestep`: Index of timestep
     * `integer(kind=)`: units = index
@@ -1156,7 +1156,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = m
 * `do_allow_supersaturation_after_sedimentation`: Do allow supersaturation after sedimentation
     * `logical(kind=)`: units = flag
-* `autoconverion_to_snow_size_threshold`: Autoconverion to snow size threshold
+* `autoconversion_to_snow_size_threshold`: Autoconversion to snow size threshold
     * `real(kind=kind_phys)`: units = um
 * `bergeron_findeisen_process_efficiency_factor`: Bergeron findeisen process efficiency factor
     * `real(kind=kind_phys)`: units = fraction
@@ -1404,7 +1404,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = 1
 * `total_amplitude_of_sppt_perturbation`: Total amplitude of sppt perturbation
     * `real(kind=kind_phys)`: units = 1
-* `do_turbulent_orographic_form_drag_in_unified_gravity_wave_physics_gravitiy_wave_drag_scheme`: Do turbulent orographic form drag in unified gravity wave physics gravitiy wave drag scheme
+* `do_turbulent_orographic_form_drag_in_unified_gravity_wave_physics_gravity_wave_drag_scheme`: Do turbulent orographic form drag in unified gravity wave physics gravity wave drag scheme
     * `logical(kind=)`: units = flag
 * `updraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme`: Updraft area fraction in scale aware tke moist edmf pbl scheme
     * `real(kind=kind_phys)`: units = fraction
@@ -1574,7 +1574,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = K2
 * `tendency_of_air_temperature_due_to_nonphysics`: Tendency of air temperature due to nonphysics
     * `real(kind=kind_phys)`: units = K s-1
-* `tendency_of_air_temperature_to_withold_from_sppt`: Tendency of air temperature to withold from sppt
+* `tendency_of_air_temperature_to_withhold_from_sppt`: Tendency of air temperature to withhold from sppt
     * `real(kind=kind_phys)`: units = K s-1
 * `tendency_of_activated_cloud_condensation_nuclei_from_climatology`: Tendency of activated cloud condensation nuclei from climatology
     * `real(kind=kind_phys)`: units = kg-1 s-1
@@ -1594,7 +1594,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = kg kg-1
 * `weight_for_momentum_at_top_of_viscous_sublayer`: Weight for momentum at top of viscous sublayer
     * `real(kind=kind_phys)`: units = 1
-* `weight_for_potental_temperature_at_top_of_viscous_sublayer`: Weight for potental temperature at top of viscous sublayer
+* `weight_for_potential_temperature_at_top_of_viscous_sublayer`: Weight for potential temperature at top of viscous sublayer
     * `real(kind=kind_phys)`: units = 1
 * `weight_for_specific_humidity_at_top_of_viscous_sublayer`: Weight for specific humidity at top of viscous sublayer
     * `real(kind=kind_phys)`: units = 1
@@ -1926,7 +1926,7 @@ Variables related to the compute environment
 ## GFS_typedefs_GFS_coupling_type
 * `cellular_automata_global_pattern_from_coupled_process`: Cellular automata global pattern from coupled process
     * `real(kind=kind_phys)`: units = 1
-* `convective_cloud_condesate_after_rainout`: Convective cloud condesate after rainout
+* `convective_cloud_condensate_after_rainout`: Convective cloud condensate after rainout
     * `real(kind=kind_phys)`: units = kg kg-1
 * `cumulative_surface_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling diffuse nir shortwave flux for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
@@ -1940,7 +1940,7 @@ Variables related to the compute environment
     * `real(kind=kind_phys)`: units = J m-2
 * `cumulative_surface_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface downwelling shortwave flux for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
-* `cumulative_surface_net_downwellling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwellling diffuse nir shortwave flux for coupling multiplied by timestep
+* `cumulative_surface_net_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling diffuse nir shortwave flux for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2
 * `cumulative_surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep`: Cumulative surface net downwelling diffuse uv and vis shortwave flux for coupling multiplied by timestep
     * `real(kind=kind_phys)`: units = J m-2

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -27,26 +27,31 @@ ESM Standard Name Rules
    an appropriate name does not exist in that standard, or the adoption
    of said names leads to inconsistencies in the naming convention.
 
-#. When no suitable standard name exists in the CF conventions, follow their
-   guidelines for standard name construction at this URL:
-   http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html. Standard
-   names may be qualified by the addition of phrases in certain standard forms and
-   order. The "Qualifications" section of the CF guidelines should be used to
-   provide information about a variable's horizontal surface (e.g. at_cloud_base),
-   component (i.e. direction of variable, e.g. downward), medium (e.g.
-   in_stratosphere), process (e.g. due_to_deep convection), or condition (e.g.,
-   assuming_clear_sky). The order defined by the CF rules should be observed. These
-   qualifications do not change the units of the quantity.
+#. When no suitable standard name exists in the CF conventions, the following guidelines should be followed for constructing a new name.
+   The phrases in brackets are optional. The words in *italic* appear explicitly as stated,
+   while the words in ``this font`` indicate other words or phrases to be substituted.
+   The new standard name is constructed by joining the base standard name to the qualifiers using underscores.
 
-   All of the following phrases in brackets are optional. The words in *italic*
-   appear explicitly as stated, while the words in ``this font`` indicate other
-   words or phrases to be substituted. The new standard name is constructed by
-   joining the base standard name to the qualifiers using underscores.
+   [``transformation``] [``component``] base_name [*at* ``level``] [*in* ``medium``] [*due_to* ``process``] [*assuming* ``condition``]
 
-   [``component``] standard_name [*at* ``level``] [*in* ``medium``]
-   [*due_to* ``process``] [*assuming* ``condition``]
+   This construction was originally based on rules set forth in the
+   `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`_),
+   but have since evolved for better consistency and generality across a broader set of fields
+   than was originally envisioned by the CF conventions. "``medium``" should be specified when
+   the variable in question is a substance or other quantity contained within some other medium
+   (e.g. for "mole_fraction_of_ozone_in_air", the base name is "ozone", while the medium is "air"). 
+   "Transformation" refers to descriptors such as "``tendency_of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_.
+   Other parts of the construction provide information about a variable's horizontal surface
+   (e.g. ``at_cloud_base``), component (i.e. direction of variable, e.g. ``downward``), process (e.g.
+   ``due_to_deep_convection``), or condition (e.g., ``assuming_clear_sky``). These qualifications do not
+   change the units of the quantity. This is not an exhaustive list of qualifiers that may be needed for a given standard name;
+   see subsequent rules below for more information.
 
-   See the list of currently-used qualifiers below for help.
+   The following table provides a few concrete examples of standard names and how they are constructed
+   with respect to the guideline template.
+
+.. image:: https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_construction_examples.png
+   :alt: image of table providing standard name construction examples
 
 #. Variables are current and instantaneous unless specified. Variables that are not
    current (e.g., previous timestep) or non-instantaneous (e.g., accumulated values)
@@ -111,14 +116,18 @@ ESM Standard Name Rules
 
 #. By default, the term *cloud* refers to all cloud phases and cloud types. Otherwise
    an additional prefix or suffix should be added to the standard name specifying what kind(s)
-   of clouds the variable repesents (e.g. *ice_cloud* if only including glaciated clouds, or
+   of clouds the variable represents (e.g. *ice_cloud* if only including glaciated clouds, or
    *cloud_at_500hPa* if only including clouds that exist at 500 hPa).
 
 #. If possible, qualifiers should be limited in order to allow for a wide
-   applicability of the variable. In other words, don't qualify with _for ``_xyz``
+   applicability of the variable. In other words, don't qualify with ``_for_specific_context``
    unless a variable could not conceivably be used outside of the more
    narrowly-defined context or a variable without the scope-narrowing qualifiers
    already exists and cannot be reused.
+
+   **Discouraged:** surface_upward_specific_humidity_flux_for_mellor_yamada_janjic_surface_layer_scheme
+
+   **Preferred:** surface_upward_specific_humidity_flux
 
 #. Spell out acronyms unless they are obvious to a vast majority of
    scientists/developers who may come across them. A list of currently-used
@@ -129,9 +138,8 @@ ESM Standard Name Rules
    use flag_for ``_X``. If it is any other data type, use control_for ``_X``. All flags
    should be Fortran logicals.
 
-#. Standard names that start with ``ccpp_`` represent CCPP framework-provided variables.
-   All other standard names should avoid the use of ``ccpp`` in their name in order
-   to avoid any confusion.
+#. Reserved names: The prefix ``ccpp_`` represents CCPP framework-provided variables.
+   All other standard names should avoid the use of ``ccpp`` in their name.
 
 #. No punctuation should appear in standard names except for underscores (_).
 
@@ -389,8 +397,24 @@ Prefixes
 | **sine_of** ``_X``
 | **variance_of** ``_X``
 
+Suffixes
+^^^^^^^^
+| ``X_`` mixing_ratio_wrt ``_Y``
+
 Other common standard name components
 =====================================
+
+Reserved phrase
+---------------
+
+These words/phrases should not be used outside of the described context
+
++------------------------+-------------------------------------------------------------------------------------+
+| **Phrase**             |  **Usage**                                                                          |
++========================+=====================================================================================+
+| ccpp                   | Variable names provided by the CCPP framework                                       |
++------------------------+-------------------------------------------------------------------------------------+
+
 
 Special phrases
 ---------------
@@ -497,9 +521,9 @@ standard names.
 +-------------------------------------------+-----------------+
 | heat_transport                            | W               |
 +-------------------------------------------+-----------------+
-| horizontal_streamfunction                 | m2 s-1          |
+| streamfunction                            | m2 s-1          |
 +-------------------------------------------+-----------------+
-| horizontal_velocity_potential             | m2 s-1          |
+| velocity_potential                        | m2 s-1          |
 +-------------------------------------------+-----------------+
 | mass                                      | kg              |
 +-------------------------------------------+-----------------+
@@ -562,7 +586,7 @@ Acronyms, Abbreviations, and Aliases
 +---------------------+---------------------------------------------------------+
 | **Short**           |  **Meaning**                                            |
 +=====================+=========================================================+
-| ir                  | infared                                                 |
+| ir                  | infrared                                                |
 +---------------------+---------------------------------------------------------+
 | lwe                 | liquid water equivalent                                 |
 +---------------------+---------------------------------------------------------+

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -27,31 +27,26 @@ ESM Standard Name Rules
    an appropriate name does not exist in that standard, or the adoption
    of said names leads to inconsistencies in the naming convention.
 
-#. When no suitable standard name exists in the CF conventions, the following guidelines should be followed for constructing a new name.
-   The phrases in brackets are optional. The words in *italic* appear explicitly as stated,
-   while the words in ``this font`` indicate other words or phrases to be substituted.
-   The new standard name is constructed by joining the base standard name to the qualifiers using underscores.
+#. When no suitable standard name exists in the CF conventions, follow their
+   guidelines for standard name construction at this URL:
+   http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html. Standard
+   names may be qualified by the addition of phrases in certain standard forms and
+   order. The "Qualifications" section of the CF guidelines should be used to
+   provide information about a variable's horizontal surface (e.g. at_cloud_base),
+   component (i.e. direction of variable, e.g. downward), medium (e.g.
+   in_stratosphere), process (e.g. due_to_deep convection), or condition (e.g.,
+   assuming_clear_sky). The order defined by the CF rules should be observed. These
+   qualifications do not change the units of the quantity.
 
-   [``transformation``] [``component``] base_name [*at* ``level``] [*in* ``medium``] [*due_to* ``process``] [*assuming* ``condition``]
+   All of the following phrases in brackets are optional. The words in *italic*
+   appear explicitly as stated, while the words in ``this font`` indicate other
+   words or phrases to be substituted. The new standard name is constructed by
+   joining the base standard name to the qualifiers using underscores.
 
-   This construction was originally based on rules set forth in the
-   `CF guidelines <http://cfconventions.org/Data/cf-standard-names/docs/guidelines.html>`_),
-   but have since evolved for better consistency and generality across a broader set of fields
-   than was originally envisioned by the CF conventions. "``medium``" should be specified when
-   the variable in question is a substance or other quantity contained within some other medium
-   (e.g. for "mole_fraction_of_ozone_in_air", the base name is "ozone", while the medium is "air"). 
-   "Transformation" refers to descriptors such as "``tendency_of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_.
-   Other parts of the construction provide information about a variable's horizontal surface
-   (e.g. ``at_cloud_base``), component (i.e. direction of variable, e.g. ``downward``), process (e.g.
-   ``due_to_deep_convection``), or condition (e.g., ``assuming_clear_sky``). These qualifications do not
-   change the units of the quantity. This is not an exhaustive list of qualifiers that may be needed for a given standard name;
-   see subsequent rules below for more information.
+   [``component``] standard_name [*at* ``level``] [*in* ``medium``]
+   [*due_to* ``process``] [*assuming* ``condition``]
 
-   The following table provides a few concrete examples of standard names and how they are constructed
-   with respect to the guideline template.
-
-.. image:: https://raw.githubusercontent.com/wiki/ESCOMP/CCPPStandardNames/images/standard_name_construction_examples.png
-   :alt: image of table providing standard name construction examples
+   See the list of currently-used qualifiers below for help.
 
 #. Variables are current and instantaneous unless specified. Variables that are not
    current (e.g., previous timestep) or non-instantaneous (e.g., accumulated values)
@@ -116,18 +111,14 @@ ESM Standard Name Rules
 
 #. By default, the term *cloud* refers to all cloud phases and cloud types. Otherwise
    an additional prefix or suffix should be added to the standard name specifying what kind(s)
-   of clouds the variable represents (e.g. *ice_cloud* if only including glaciated clouds, or
+   of clouds the variable repesents (e.g. *ice_cloud* if only including glaciated clouds, or
    *cloud_at_500hPa* if only including clouds that exist at 500 hPa).
 
 #. If possible, qualifiers should be limited in order to allow for a wide
-   applicability of the variable. In other words, don't qualify with ``_for_specific_context``
+   applicability of the variable. In other words, don't qualify with _for ``_xyz``
    unless a variable could not conceivably be used outside of the more
    narrowly-defined context or a variable without the scope-narrowing qualifiers
    already exists and cannot be reused.
-
-   **Discouraged:** surface_upward_specific_humidity_flux_for_mellor_yamada_janjic_surface_layer_scheme
-
-   **Preferred:** surface_upward_specific_humidity_flux
 
 #. Spell out acronyms unless they are obvious to a vast majority of
    scientists/developers who may come across them. A list of currently-used
@@ -138,8 +129,9 @@ ESM Standard Name Rules
    use flag_for ``_X``. If it is any other data type, use control_for ``_X``. All flags
    should be Fortran logicals.
 
-#. Reserved names: The prefix ``ccpp_`` represents CCPP framework-provided variables.
-   All other standard names should avoid the use of ``ccpp`` in their name.
+#. Standard names that start with ``ccpp_`` represent CCPP framework-provided variables.
+   All other standard names should avoid the use of ``ccpp`` in their name in order
+   to avoid any confusion.
 
 #. No punctuation should appear in standard names except for underscores (_).
 
@@ -397,24 +389,8 @@ Prefixes
 | **sine_of** ``_X``
 | **variance_of** ``_X``
 
-Suffixes
-^^^^^^^^
-| ``X_`` mixing_ratio_wrt ``_Y``
-
 Other common standard name components
 =====================================
-
-Reserved phrase
----------------
-
-These words/phrases should not be used outside of the described context
-
-+------------------------+-------------------------------------------------------------------------------------+
-| **Phrase**             |  **Usage**                                                                          |
-+========================+=====================================================================================+
-| ccpp                   | Variable names provided by the CCPP framework                                       |
-+------------------------+-------------------------------------------------------------------------------------+
-
 
 Special phrases
 ---------------
@@ -521,9 +497,9 @@ standard names.
 +-------------------------------------------+-----------------+
 | heat_transport                            | W               |
 +-------------------------------------------+-----------------+
-| streamfunction                            | m2 s-1          |
+| horizontal_streamfunction                 | m2 s-1          |
 +-------------------------------------------+-----------------+
-| velocity_potential                        | m2 s-1          |
+| horizontal_velocity_potential             | m2 s-1          |
 +-------------------------------------------+-----------------+
 | mass                                      | kg              |
 +-------------------------------------------+-----------------+
@@ -586,7 +562,7 @@ Acronyms, Abbreviations, and Aliases
 +---------------------+---------------------------------------------------------+
 | **Short**           |  **Meaning**                                            |
 +=====================+=========================================================+
-| ir                  | infrared                                                |
+| ir                  | infared                                                 |
 +---------------------+---------------------------------------------------------+
 | lwe                 | liquid water equivalent                                 |
 +---------------------+---------------------------------------------------------+

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -115,7 +115,7 @@
     </standard_name>
     <standard_name
         name="standard_gravitational_acceleration"
-        long_name="scalar constant representing gravitiational acceleration">
+        long_name="scalar constant representing gravitational acceleration">
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
   </section>
@@ -365,11 +365,11 @@
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="air_horizontal_streamfunction"
-                   long_name="Scalar function describing the stream lines of the wind">
+                   long_name="Scalar function describing the streamlines of the horizontal wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="air_horizontal_velocity_potential"
-                   long_name="Scalar potential of the wind">
+                   long_name="Scalar potential of the horizontal wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="air_upward_absolute_vorticity"
@@ -969,7 +969,7 @@
       <standard_name name="aerosol_aware_multiplicative_rain_conversion_parameter_for_shallow_convection">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="number_of_microphysics_varaibles_in_xy_dimensioned_restart_array">
+      <standard_name name="number_of_microphysics_variables_in_xy_dimensioned_restart_array">
          <type kind="" units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_microphysics_variables_in_xyz_dimensioned_restart_array">
@@ -1260,7 +1260,7 @@
       <standard_name name="control_for_land_surface_scheme_dynamic_vegetation">
          <type kind="" units="1">integer</type>
       </standard_name>
-      <standard_name name="indentifier_for_exponential_cloud_overlap_method">
+      <standard_name name="identifier_for_exponential_cloud_overlap_method">
          <type kind="" units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_exponential_random_cloud_overlap_method">
@@ -1509,7 +1509,7 @@
       <standard_name name="control_for_land_surface_scheme_runoff_and_groundwater">
          <type kind="" units="1">integer</type>
       </standard_name>
-      <standard_name name="identifer_for_scale_aware_mass_flux_deep_convection">
+      <standard_name name="identifier_for_scale_aware_mass_flux_deep_convection">
          <type kind="" units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_scale_aware_mass_flux_shallow_convection">
@@ -1839,7 +1839,7 @@
       <standard_name name="index_of_upward_virtual_potential_temperature_flux_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
-      <standard_name name="index_of_subgrid_cloud_area_fracation_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
+      <standard_name name="index_of_subgrid_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
          <type kind="" units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_timestep">
@@ -1884,7 +1884,7 @@
       <standard_name name="do_allow_supersaturation_after_sedimentation">
          <type kind="" units="flag">logical</type>
       </standard_name>
-      <standard_name name="autoconverion_to_snow_size_threshold">
+      <standard_name name="autoconversion_to_snow_size_threshold">
          <type kind="kind_phys" units="um">real</type>
       </standard_name>
       <standard_name name="bergeron_findeisen_process_efficiency_factor">
@@ -2256,7 +2256,7 @@
       <standard_name name="total_amplitude_of_sppt_perturbation">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="do_turbulent_orographic_form_drag_in_unified_gravity_wave_physics_gravitiy_wave_drag_scheme">
+      <standard_name name="do_turbulent_orographic_form_drag_in_unified_gravity_wave_physics_gravity_wave_drag_scheme">
          <type kind="" units="flag">logical</type>
       </standard_name>
       <standard_name name="updraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme">
@@ -2512,7 +2512,7 @@
       <standard_name name="tendency_of_air_temperature_due_to_nonphysics">
          <type kind="kind_phys" units="K s-1">real</type>
       </standard_name>
-      <standard_name name="tendency_of_air_temperature_to_withold_from_sppt">
+      <standard_name name="tendency_of_air_temperature_to_withhold_from_sppt">
          <type kind="kind_phys" units="K s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_activated_cloud_condensation_nuclei_from_climatology">
@@ -2542,7 +2542,7 @@
       <standard_name name="weight_for_momentum_at_top_of_viscous_sublayer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="weight_for_potental_temperature_at_top_of_viscous_sublayer">
+      <standard_name name="weight_for_potential_temperature_at_top_of_viscous_sublayer">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
       <standard_name name="weight_for_specific_humidity_at_top_of_viscous_sublayer">
@@ -3049,7 +3049,7 @@
       <standard_name name="cellular_automata_global_pattern_from_coupled_process">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="convective_cloud_condesate_after_rainout">
+      <standard_name name="convective_cloud_condensate_after_rainout">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cumulative_surface_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep">
@@ -3070,7 +3070,7 @@
       <standard_name name="cumulative_surface_downwelling_shortwave_flux_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
-      <standard_name name="cumulative_surface_net_downwellling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep">
+      <standard_name name="cumulative_surface_net_downwelling_diffuse_nir_shortwave_flux_for_coupling_multiplied_by_timestep">
          <type kind="kind_phys" units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_surface_net_downwelling_diffuse_uv_and_vis_shortwave_flux_for_coupling_multiplied_by_timestep">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -365,11 +365,11 @@
       <type kind="kind_phys" units="m s-2">real</type>
     </standard_name>
     <standard_name name="air_horizontal_streamfunction"
-                   long_name="Scalar function describing the streamlines of the horizontal wind">
+                   long_name="Scalar function describing the stream lines of the wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="air_horizontal_velocity_potential"
-                   long_name="Scalar potential of the horizontal wind">
+                   long_name="Scalar potential of the wind">
       <type kind="kind_phys" units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="air_upward_absolute_vorticity"


### PR DESCRIPTION
There are many misspellings in the existing `main` branch, not only in the `long_name` descriptions but in the `standard_name` entries themselves. This PR addresses the ones I have identified so far.