### PR TITLE
Remove a code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 
-*       @cacraigucar @climbfuji @dustinswales @gold2718 @grantfirl @mattldawson @mkavulich @mwaxmonsky @nusbaume @peverwhee @svahl991 @MayeulDestouches @ss421
+*       @cacraigucar @climbfuji @dustinswales @gold2718 @grantfirl @mattldawson @mkavulich @mwaxmonsky @nusbaume @peverwhee @svahl991 @ss421
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 
-*       @cacraigucar @climbfuji @dustinswales @gold2718 @grantfirl @mattldawson @mkavulich @mwaxmonsky @nusbaume @peverwhee @svahl991 @ss421
+*       @cacraigucar @climbfuji @dustinswales @gold2718 @grantfirl @mattldawson @mkavulich @mwaxmonsky @nusbaume @peverwhee @MarekWlasak @svahl991 @ss421
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners


### PR DESCRIPTION
## Description

This PR removes me as a code owner. The reason why I was a code owner was because of the UK Met Office involvement in the project, and I have now left the Met Office. 