### PR TITLE
Add glomap/UKCA dust mode variables

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -8,6 +8,7 @@
 * [diagnostics](#diagnostics)
 * [atmospheric_composition](#atmospheric_composition)
 * [atmospheric_composition: GOCART aerosols](#atmospheric_composition-gocart-aerosols)
+* [atmospheric_composition: GLOMAP/UKCA aerosols](#atmospheric_composition-glomapukca-aerosols)
 * [emissions](#emissions)
 * [Application-specific variables](#application-specific-variables)
 * [system variables](#system-variables)
@@ -449,6 +450,15 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = m-1
 * `volume_extinction_in_air_due_to_aerosol_particles_lambda3`: Aerosol extinction at wavelength3
     * `real(kind=kind_phys)`: units = m-1
+## atmospheric_composition: GLOMAP/UKCA aerosols
+* `mass_fraction_of_dust_coarse_aerosol_particles_in_air`: Mass fraction of coarse mode dust aerosol particles
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `mass_fraction_of_dust_accumulation_aerosol_particles_in_air`: Mass fraction of accumulation mode dust aerosol particles
+    * `real(kind=kind_phys)`: units = kg kg-1
+* `number_fraction_of_coarse_aerosol_particles_in_air`: Number fraction of coarse mode dust aerosol particles
+    * `real(kind=kind_phys)`: units = 1
+* `number_fraction_of_accumulation_aerosol_particles_in_air`: Number fraction of accumulation mode dust aerosol particles
+    * `real(kind=kind_phys)`: units = 1
 ## emissions
 Emissions variables, contributed for the Community Emissions Data System (CEDS)
 * `emissions_of_co_due_to_anthropogenic`: Carbon monoxide emissions from anthropogenic sources, total

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -787,6 +787,24 @@
       <type kind="kind_phys" units="m-1">real</type>
     </standard_name>
   </section>
+  <section name="atmospheric_composition: GLOMAP/UKCA aerosols">
+    <standard_name name="mass_fraction_of_dust_coarse_aerosol_particles_in_air"
+                   long_name="Mass fraction of coarse mode dust aerosol particles">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="mass_fraction_of_dust_accumulation_aerosol_particles_in_air"
+                   long_name="Mass fraction of accumulation mode dust aerosol particles">
+      <type kind="kind_phys" units="kg kg-1">real</type>
+    </standard_name>
+    <standard_name name="number_fraction_of_coarse_aerosol_particles_in_air"
+                   long_name="Number fraction of coarse mode dust aerosol particles">
+      <type kind="kind_phys" units="1">real</type>
+    </standard_name>
+      <standard_name name="number_fraction_of_accumulation_aerosol_particles_in_air"
+                   long_name="Number fraction of accumulation mode dust aerosol particles">
+      <type kind="kind_phys" units="1">real</type>
+    </standard_name>
+  </section>
   <section name="emissions"
            comment="Emissions variables, contributed for the Community Emissions Data System (CEDS)">
     <standard_name name="emissions_of_co_due_to_anthropogenic"


### PR DESCRIPTION
This PR adds in new aerosol variables needed for the Met Office LFRIC forecast model. These are the number and mass fractions for the two dust modes in the UKCA/GLOMAP aerosol model.