### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,27 @@
+<!-- Please read all instructions, then fill out the following template.-->
+
+<!-- Include a short, descriptive title in the field above. If this PR is for a branch other than
+`main`, include the destination branch name in brackets at the beginning, e.g.:
+
+[release/v1] Bugfix for release/v1 branch
+
+Tag this pull request with appropriate labels. If you do not have permission to add labels, list
+the labels you’d like to include in your PR description
+
+If this PR is not ready to be reviewed or merged, open as a draft, and include "DRAFT:" as a prefix
+to the title above.
+
+Developers listed in the CODEOWNERS file will automatically be assigned to review your Pull Request.
+If your contribution should be reviewed by anyone else, assign those reviewers manually from the
+menu at right, or by tagging them with @USERNAME in the Description text.
+
+Be sure to check in on the PR regularly to respond to comments/questions/reviews!
+--> 
+
+## Description
+<!-- One or more paragraphs describing the proposed changes and the reasoning behind them. -->
+
+## Issues
+<!-- Link any associated GitHub issues in this or other repositories here. -->
+
+


### PR DESCRIPTION
## Description
Add a Pull Request template providing instructions on what information to include when opening a Pull Request. Some rules/guidelines initially in the [governance document](https://github.com/ESCOMP/ESMStandardNames/wiki/Governance-and-Development-Workflow-for-ESM-Standard-Names) have been moved here as well.