### PR TITLE
[release/v1] Fifth major update in v1 branch: Better information on units, remove `kind`, clarify disallowed terms

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -57,7 +57,7 @@ more specific standard names.
     * `real`: units = W
 * `mass`: Mass
     * `real`: units = kg
-* `mass_content`: Integrated mass over a given area and vertical extent
+* `mass_content`: Vertically-integrated mass over a given area and vertical extent
     * `real`: units = kg m-2
 * `mass_flux`: Mass traveling through an area per unit time
     * `real`: units = kg m-2 s-1
@@ -313,7 +313,7 @@ Constant parameters that should be identical across a full modeling system
     * `real`: units = J K-1
 * `density_of_dry_air_at_stp`: Density of dry air at standard temperature and pressure
     * `real`: units = kg m-3
-* `fresh_liquid_water_density_at_0c`: Density of liquid water at 0 degrees Celsius
+* `density_of_fresh_liquid_water_at_0c`: Density of liquid water at 0 degrees Celsius
     * `real`: units = kg m-3
 * `gas_constant_of_dry_air`: Gas constant of dry air
     * `real`: units = J kg-1 K-1
@@ -382,7 +382,7 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real`: units = degrees
 * `dry_static_energy`: Dry static energy content of atmosphere layer
     * `real`: units = J kg-1
-* `flag_for_lagrangian_vertical_coordinate`: Flag indicating if vertical coordinate is lagrangian
+* `do_lagrangian_vertical_coordinate`: Flag indicating if vertical coordinate is lagrangian
     * `logical`: units = flag
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
     * `real`: units = Pa s-1

--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -31,8 +31,6 @@ Base names can roughly be broken down into three categories:
 The following names are too general to be chosen as
 standard names, but they can serve as base names for
 more specific standard names.
-* `amount`: Amount
-    * `real`: units = kg m-2
 * `area`: Area
     * `real`: units = m2
 * `area_fraction`: The fraction of an area where some condition applies
@@ -59,6 +57,8 @@ more specific standard names.
     * `real`: units = W
 * `mass`: Mass
     * `real`: units = kg
+* `mass_content`: Integrated mass over a given area and vertical extent
+    * `real`: units = kg m-2
 * `mass_flux`: Mass traveling through an area per unit time
     * `real`: units = kg m-2 s-1
 * `mass_fraction`: The fraction of a given mass where some condition applies
@@ -150,7 +150,7 @@ full list of standard names for further details.
     * `real`: units = s-1
 * `air_pressure`: The pressure of air
     * `real`: units = Pa
-* `air_pressure_thickness`: Air pressure thickness
+* `air_pressure_thickness`: The difference in air pressure between two vertical layers
     * `real`: units = Pa
 * `air_temperature`: The temperature of air
     * `real`: units = K
@@ -183,12 +183,12 @@ full list of standard names for further details.
     * `real`: units = 1
 * `divergence`: Divergence
     * `real`: units = s-1
-* `dry_air_density`: Density of air excluding water vapor component
+* `dry_air`: Air excluding all water components
     * `real`: units = kg m-3
 * `dry_air_enthalpy_at_constant_pressure`: Specific enthalpy of dry air, h = Cp*T; Cp = Specific heat of dry air at constant pressure, T = temperature
     * `real`: units = J kg-1
 * `exner_function`: Exner function, (p/p0)^(Rd/cp), where p0 is some reference pressure (1000 hPa if not specified)
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `friction_velocity`: A measure of shear stress within a fluid layer with units of distance per time
     * `real`: units = m s-1
 * `filename`: Filename
@@ -196,7 +196,7 @@ full list of standard names for further details.
 * `forecast_time`: Forecast time
     * `real`: units = h
 * `geopotential`: Gravitational potential energy of a unit mass relative to sea level
-    * `real(kind=kind_phys)`: units = m2 s-2
+    * `real`: units = m2 s-2
 * `geopotential_height`: Geopotential divided by the gravitational constant
     * `real`: units = m
 * `graupel`: Precipitation consisting of heavily rimed ice crystals
@@ -304,2205 +304,2206 @@ Currently, the only dimension which supports all six dimension types is horizont
 * `number_of_openmp_threads`: Total number of OpenMP (shared-memory) parallel threads.
     * `integer`: units = count
 ## constants
+Constant parameters that should be identical across a full modeling system
 * `avogadro_number`: Avogadro number
-    * `real(kind=kind_phys)`: units = molecules mol-1
+    * `real`: units = molecules mol-1
 * `base_state_surface_pressure_for_hybrid_vertical_coordinate`: Base state surface pressure for hybrid vertical coordinate
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `boltzmann_constant`: Boltzmann constant
-    * `real(kind=kind_phys)`: units = J K-1
-* `gas_constant_of_dry_air`: Gas constant of dry air
-    * `real(kind=kind_phys)`: units = J kg-1 K-1
-* `seconds_in_calendar_day`: Seconds in calendar day
-    * `integer(kind=kind_phys)`: units = s
-* `specific_heat_of_dry_air_at_constant_pressure`: Specific heat of dry air at constant pressure
-    * `real(kind=kind_phys)`: units = J kg-1 K-1
-* `specific_heat_of_liquid_water_at_20c`: Specific heat of liquid water at 20 degrees Celsius
-    * `real(kind=kind_phys)`: units = J kg-1 K-1
-* `latent_heat_of_vaporization_of_water_at_0c`: Latent heat of vaporization of water at 0 degrees Celsius
-    * `real(kind=kind_phys)`: units = J kg-1
-* `dry_air_density_at_stp`: Density of dry air at standard temperature and pressure
-    * `real(kind=kind_phys)`: units = kg m-3
+    * `real`: units = J K-1
+* `density_of_dry_air_at_stp`: Density of dry air at standard temperature and pressure
+    * `real`: units = kg m-3
 * `fresh_liquid_water_density_at_0c`: Density of liquid water at 0 degrees Celsius
-    * `real(kind=kind_phys)`: units = kg m-3
+    * `real`: units = kg m-3
+* `gas_constant_of_dry_air`: Gas constant of dry air
+    * `real`: units = J kg-1 K-1
+* `latent_heat_of_vaporization_of_water_at_0c`: Latent heat of vaporization of water at 0 degrees Celsius
+    * `real`: units = J kg-1
 * `ratio_of_water_vapor_to_dry_air_gas_constants_minus_one`: Ratio of gas constants of water vapor and dry air minus one; (Rwv / Rdair) - 1.0
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
+* `seconds_in_calendar_day`: Seconds in calendar day
+    * `integer`: units = s
+* `specific_heat_of_liquid_water_at_20c`: Specific heat of liquid water at 20 degrees Celsius
+    * `real`: units = J kg-1 K-1
 * `standard_gravitational_acceleration`: scalar constant representing gravitational acceleration
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 ## coordinates
 * `latitude`: Latitude
-    * `real(kind=kind_phys)`: units = degree_north
+    * `real`: units = degree_north
 * `longitude`: Longitude
-    * `real(kind=kind_phys)`: units = degree_east
+    * `real`: units = degree_east
 * `cell_area`: Cell area
-    * `real(kind=kind_phys)`: units = m2
+    * `real`: units = m2
 * `cell_scaling_factor`: Cell scaling factor
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 ## state_variables
 Note that appending '_on_previous_timestep' to standard_names in this section yields another valid standard_name
+* `specific_heat_of_dry_air_at_constant_pressure`: Specific heat of dry air at constant pressure
+    * `real`: units = J kg-1 K-1
 * `physics_state_due_to_dynamics`: Physics state due to dynamics
-    * `physics_state(kind=kind_phys)`: units = none
+    * `physics_state`: units = none
 * `timestep_for_physics`: Timestep for physics
-    * `integer(kind=kind_phys)`: units = s
+    * `integer`: units = s
 * `total_tendency_of_physics`: Total tendency of physics
-    * `physics_tend(kind=kind_phys)`: units = none
+    * `physics_tend`: units = none
 * `air_pressure_at_top_of_atmosphere_model`: Air pressure at top of atmosphere model
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_at_sea_level`: Air pressure at sea level
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_at_surface`: Air pressure at local surface
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `surface_pressure_of_dry_air`: Surface pressure of dry air
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `geopotential_at_surface`: Geopotential at surface
-    * `real(kind=kind_phys)`: units = m2 s-2
+    * `real`: units = m2 s-2
 * `air_temperature`: Air temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `air_temperature_on_previous_timestep`: Air temperature on previous timestep
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `x_wind`: Horizontal wind in a direction perpendicular to y_wind
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `y_wind`: Horizontal wind in a direction perpendicular to x_wind
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `eastward_wind`: Wind vector component, positive when directed eastward
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `northward_wind`: Wind vector component, positive when directed northward
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `eastward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed eastward
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `northward_wind_at_10m`: Wind vector component at 10 meters above surface, positive when directed northward
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `eastward_wind_at_surface`: Wind vector component closest to surface, positive when directed eastward
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `northward_wind_at_surface`: Wind vector component closest to surface, positive when directed northward
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `wind_speed_at_surface`: Scalar wind speed closest to surface
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `wind_from_direction_at_surface`: Direction, from north, of wind speed closest to surface
-    * `real(kind=kind_phys)`: units = degrees
+    * `real`: units = degrees
 * `dry_static_energy`: Dry static energy content of atmosphere layer
-    * `real(kind=kind_phys)`: units = J kg-1
-* `do_lagrangian_vertical_coordinate`: Flag indicating if vertical coordinate is lagrangian
-    * `logical(kind=)`: units = flag
+    * `real`: units = J kg-1
+* `flag_for_lagrangian_vertical_coordinate`: Flag indicating if vertical coordinate is lagrangian
+    * `logical`: units = flag
 * `lagrangian_tendency_of_air_pressure`: Vertical pressure velocity
-    * `real(kind=kind_phys)`: units = Pa s-1
-* `dry_air_density`: Density of dry air
-    * `real(kind=kind_phys)`: units = kg m-3
+    * `real`: units = Pa s-1
+* `density_of_dry_air`: Density of dry air
+    * `real`: units = kg m-3
 * `air_pressure`: Midpoint air pressure
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_of_dry_air`: Dry midpoint pressure
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_thickness`: Air pressure thickness
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_thickness_of_dry_air`: Air pressure thickness of dry air
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `reciprocal_of_air_pressure_thickness`: Reciprocal of air pressure thickness
-    * `real(kind=kind_phys)`: units = Pa-1
+    * `real`: units = Pa-1
 * `reciprocal_of_air_pressure_thickness_of_dry_air`: Reciprocal of air pressure thickness of dry air
-    * `real(kind=kind_phys)`: units = Pa-1
+    * `real`: units = Pa-1
 * `ln_air_pressure`: Ln air pressure
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `ln_air_pressure_of_dry_air`: Ln air pressure of dry air
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `reciprocal_of_exner_function_wrt_air_pressure_at_surface`: inverse exner function with respect to surface pressure; (ps/p)^(R/cp)
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `geopotential_height`: geopotential height with respect to sea level
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `geopotential_height_at_surface`: Geopotential height at local surface with respect to sea level
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `geopotential_height_wrt_surface`: geopotential height with respect to local surface
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `geopotential_height_wrt_surface_at_interfaces`: geopotential height with respect to local surface at interfaces
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `potentially_advected_quantities`: Potentially advected quantities
-    * `real(kind=kind_phys)`: units = various
+    * `real`: units = various
 * `air_pressure_at_interfaces`: Air pressure at interfaces
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_of_dry_air_at_interfaces`: Air pressure of dry air at interfaces
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `ln_air_pressure_at_interfaces`: Ln air pressure at interfaces
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `ln_air_pressure_of_dry_air_at_interfaces`: Ln air pressure of dry air at interfaces
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `air_pressure_extended_up_by_1`: Air pressure extended up by 1
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `largest_model_top_pressure_that_allows_molecular_diffusion`: Largest model top pressure that allows molecular diffusion
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `do_molecular_diffusion`: Do molecular diffusion
-    * `logical(kind=kind_phys)`: units = flag
+    * `logical`: units = flag
 * `is_initialized_physics_grid`: Flag to indicate if physics grid is initialized
-    * `logical(kind=kind_phys)`: units = flag
+    * `logical`: units = flag
 * `control_for_negative_constituent_warning`: Logging setting for negative constituent mass fixer
-    * `character(kind=len=*)`: units = 1
+    * `character`: units = 1
 * `geopotential_height_at_interfaces`: Geopotential height at interfaces
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `vertically_integrated_total_energy_of_initial_state`: Vertically integrated total energy of initial state
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `vertically_integrated_total_energy_of_current_state`: Vertically integrated total energy of current state
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `vertically_integrated_total_water_of_initial_state`: Vertically integrated total water of initial state
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `vertically_integrated_total_water_of_current_state`: Vertically integrated total water of current state
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `tendency_of_dry_air_enthalpy_at_constant_pressure`: Change of dry air enthalpy per unit time at constant pressure; d/dt(Cp*T)
-    * `real(kind=kind_phys)`: units = J kg-1 s-1
+    * `real`: units = J kg-1 s-1
 * `tendency_of_air_temperature`: Change in temperature per unit time
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_model_physics`: Change in air temperature due to model physics per unit time
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_potential_temperature_of_air`: Change in potential temperature per unit time
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_potential_temperature_of_air_due_to_model_physics`: Change of potential temperature of air due to model physics per unit time
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_x_wind`: Change in x wind per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `tendency_of_x_wind_due_to_model_physics`: Change in x wind due to model physics per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `tendency_of_y_wind`: Change in y wind per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `tendency_of_y_wind_due_to_model_physics`: Change in y wind due to model physics per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `tendency_of_eastward_wind`: Change in eastward wind per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `tendency_of_eastward_wind_due_to_model_physics`: Change in eastward wind due to model physics per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `tendency_of_northward_wind`: Change in northward wind per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `tendency_of_northward_wind_due_to_model_physics`: Change in northward wind due to model physics per unit time
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `horizontal_streamfunction_of_air`: Scalar function describing the streamlines of the horizontal wind
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `horizontal_velocity_potential_of_air`: Scalar potential of the horizontal wind
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `upward_absolute_vorticity_of_air`: The upward (kth) component of the curl of the vector wind field
-    * `real(kind=kind_phys)`: units = s-1
+    * `real`: units = s-1
 * `horizontal_divergence_of_air`: The horizontal divergence of the 2-D vector wind field
-    * `real(kind=kind_phys)`: units = s-1
+    * `real`: units = s-1
 * `upward_heat_flux_in_air_at_surface`: Upward heat flux in air at surface
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `cumulative_boundary_flux_of_total_energy`: Cumulative boundary flux of total energy
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `cumulative_boundary_flux_of_total_water`: Cumulative boundary flux of total water
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `us_standard_air_pressure_at_sea_level`: US Standard Atmospheric pressure at sea level
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `surface_reference_pressure`: Reference pressure used in definition of some other quantity (e.g. potential temperature, Exner function, etc.)
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `reference_pressure_in_atmosphere_layer`: Reference pressure in atmosphere layer
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `reference_air_pressure_normalized_by_air_pressure_at_surface`: reference pressure normalized by surface pressure
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure`: Reference pressure in atmosphere layer normalized by surface reference pressure
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `exner_function`: exner function, (p/p0)^(Rd/cp), where p0 is 1000 hPa
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `potential_temperature_of_air`: air potential temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `potential_temperature_of_air_on_previous_timestep`: air potential temperature on previous timestep
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `composition_dependent_gas_constant_of_dry_air`: Composition dependent gas constant of dry air
-    * `real(kind=kind_phys)`: units = J kg-1 K-1
+    * `real`: units = J kg-1 K-1
 * `composition_dependent_specific_heat_of_dry_air_at_constant_pressure`: composition-dependent specific heat of dry air at constant pressure
-    * `real(kind=kind_phys)`: units = J kg-1 K-1
+    * `real`: units = J kg-1 K-1
 * `composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure`: composition-dependent ratio of dry air gas constant to specific heat of dry air at constant pressure
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one`: Ratio of gas constants of water vapor to composition-dependent dry air minus one; (Rwv / Rdair) - 1.0
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `mass_content_of_cloud_ice_in_atmosphere_layer`: Mass content of cloud ice in atmosphere layer
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `mass_content_of_cloud_liquid_water_in_atmosphere_layer`: Mass content of cloud liquid water in atmosphere layer
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `mass_content_of_rain_in_atmosphere_layer`: Mass content of rain in atmosphere layer
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `mass_content_of_snow_in_atmosphere_layer`: Mass content of snow in atmosphere layer
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `mass_content_of_graupel_in_atmosphere_layer`: Mass content of graupel in atmosphere layer
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `mass_content_of_hail_in_atmosphere_layer`: Mass content of hail in atmosphere layer
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `nonconvective_cloud_area_fraction_in_atmosphere_layer`: cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `relative_humidity`: Relative humidity
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `relative_humidity_at_2m`: Relative humidity at 2m
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `gravitational_acceleration`: Gravitational acceleration
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 ## land_surface
 * `land_ice_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is ice over land
-    * `real(kind=kind_phys)`: units = frac
+    * `real`: units = frac
 * `mass_content_of_water_in_top_soil_layer`: mass per unit area of water in top layer of soil
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = kg m-2
 * `density_of_snow_at_surface`: Density of snow at surface
-    * `real(kind=kind_phys)`: units = kg m-3
+    * `real`: units = kg m-3
 * `urban_area_fraction_of_cell_area`: fraction of horizontal area of grid cell that is urban
-    * `real(kind=kind_phys)`: units = frac
+    * `real`: units = frac
 * `volume_fraction_of_liquid_water_in_soil_at_critical_point`: volume fraction of water in liquid phase in soil at critical point
-    * `real(kind=kind_phys)`: units = m3 m-3
+    * `real`: units = m3 m-3
 * `volume_fraction_of_liquid_water_in_soil_at_saturation`: volume fraction of water in liquid phase in soil at saturation
-    * `real(kind=kind_phys)`: units = m3 m-3
+    * `real`: units = m3 m-3
 * `volume_fraction_of_liquid_water_in_soil_at_wilting_point`: volume fraction of water in liquid phase in soil at wilting point
-    * `real(kind=kind_phys)`: units = m3 m-3
+    * `real`: units = m3 m-3
 ## diagnostics
 * `total_precipitation_rate_at_surface`: Total precipitation rate at surface
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 ## atmospheric_composition
 * `number_of_chemical_species`: Number of chemical species
-    * `integer(kind=kind_phys)`: units = count
+    * `integer`: units = count
 * `number_of_tracers`: Number of tracers
-    * `integer(kind=kind_phys)`: units = count
+    * `integer`: units = count
 * `water_vapor_mixing_ratio_wrt_moist_air`: Ratio of the mass of water vapor to the mass of moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of water vapor to the mass of moist air and hydrometeors at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mole_fraction_of_water_vapor`: Mole fraction of water vapor
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `water_vapor_mixing_ratio_wrt_dry_air`: Ratio of the mass of water vapor to the mass of dry air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of cloud liquid water to the mass of moist air and condensed water
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of cloud liquid water to the mass of moist air and condensed water at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air`: Ratio of the mass of cloud liquid water to the mass of moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud liquid water to the mass of dry air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud liquid water to the mass of dry air at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water`: Ratio of the mass of cloud ice to the mass of moist air and condensed water
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: Ratio of the mass of cloud ice to the mass of moist air and condensed water at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air`: Ratio of the mass of cloud ice to the mass of dry air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces`: Ratio of the mass of cloud ice to the mass of dry air at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air_and_condensed_water`: ratio of the mass of rain to the mass of moist air and condensed water
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: ratio of the mass of rain to the mass of moist air and condensed water at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `rain_mixing_ratio_wrt_moist_air`: ratio of the mass of rain to the mass of moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `rain_mixing_ratio_wrt_dry_air`: ratio of the mass of rain to the mass of dry air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `rain_mixing_ratio_wrt_dry_air_at_top_interfaces`: ratio of the mass of rain to the mass of dry air at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `total_water_mixing_ratio_wrt_moist_air_and_condensed_water`: ratio of the mass of all water phases to the mass of moist air and condensed water
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `total_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces`: ratio of the mass of all water phases to the mass of moist air and condensed water at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `total_water_mixing_ratio_wrt_dry_air`: ratio of the mass of all water phases to the mass of dry air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `total_water_mixing_ratio_wrt_dry_air_at_top_interfaces`: ratio of the mass of all water phases to the mass of dry air at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation`: saturated water vapor mass mixing ratio with respect to moist air and condensed water
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces_assuming_saturation`: saturated water vapor mass mixing ratio with respect to moist air and condensed water at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature`: derivative of the natural logarithm of water vapor partial pressure at saturation with respect to air temperature
-    * `real(kind=kind_phys)`: units = K-1
+    * `real`: units = K-1
 * `derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature_at_top_interfaces`: derivative of the natural logarithm of water vapor partial pressure at saturation with respect to air temperature at all interfaces excluding surface
-    * `real(kind=kind_phys)`: units = K-1
+    * `real`: units = K-1
 * `mole_fraction_of_ozone_in_air`: Mole fraction of ozone in air
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `mole_fraction_of_co2_in_air`: Mole fraction of co2 in air
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_ch4`: Methane volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_co`: Carbon monoxide volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_co2`: Carbon dioxide volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_ccl4`: Tetrachloromethane volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_cfc11`: Trichlorofluoromethane volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_cfc12`: Dichlorodifluoromethane volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_cfc113`: 1,1,2-Trichloro-1,2,2-trifluoroethane volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_cfc22`: Chlorodifluoromethane volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_o2`: Dioxygen volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_n2o`: Nitrous oxide volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_no2`: Nitrogen dioxide volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_no`: Nitric oxide volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_o3`: Ozone volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_hcho`: Formaldehyde volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_c5h8`: Isoprene volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 * `volume_mixing_ratio_of_so2`: Sulfur dioxide volume mixing ratio
-    * `real(kind=kind_phys)`: units = mol mol-1
+    * `real`: units = mol mol-1
 ## atmospheric_composition: GOCART aerosols
 * `mass_fraction_of_dust001_in_air`: Dust bin1 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_dust002_in_air`: Dust bin2 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_dust003_in_air`: Dust bin3 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_dust004_in_air`: Dust bin4 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_dust005_in_air`: Dust bin5 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_salt001_in_air`: Sea salt bin1 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_salt002_in_air`: Sea salt bin2 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_salt003_in_air`: Sea salt bin3 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_salt004_in_air`: Sea salt bin4 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_salt005_in_air`: Sea salt bin5 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_hydrophobic_black_carbon_in_air`: Hydrophobic black carbon mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_hydrophilic_black_carbon_in_air`: Hydrophilic black carbon mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_hydrophobic_organic_carbon_in_air`: Hydrophobic organic carbon mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_hydrophilic_organic_carbon_in_air`: Hydrophilic organic carbon mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sulfate_in_air`: Sulfate mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_nitrate001_in_air`: Nitrate bin1 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_nitrate002_in_air`: Nitrate bin2 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_fraction_of_sea_nitrate003_in_air`: Nitrate bin3 mass fraction
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `volume_extinction_in_air_due_to_aerosol_particles_lambda1`: Aerosol extinction at wavelength1
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 * `volume_extinction_in_air_due_to_aerosol_particles_lambda2`: Aerosol extinction at wavelength2
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 * `volume_extinction_in_air_due_to_aerosol_particles_lambda3`: Aerosol extinction at wavelength3
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 ## emissions
 Emissions variables, contributed for the Community Emissions Data System (CEDS)
 * `emissions_of_co_due_to_anthropogenic_sources`: Carbon monoxide emissions from anthropogenic sources, total
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_sources`: Nitric oxide emissions from anthropogenic sources, total
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_sources`: Formaldehyde emissions from anthropogenic sources, total
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_agriculture`: Carbon monoxide emissions from anthropogenic non-combustion agricultural sector
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_agriculture`: Nitric oxide emissions from anthropogenic non-combustion agricultural sector
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_agriculture`: Formaldehyde emissions from anthropogenic non-combustion agricultural sector
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_energy`: Carbon monoxide emissions from anthropogenic non-combustion energy transformation and extraction
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_energy`: Nitric oxide emissions from anthropogenic non-combustion energy transformation and extraction
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_energy`: Formaldehyde emissions from anthropogenic non-combustion energy transformation and extraction
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_industry`: Carbon monoxide emissions from anthropogenic industrial combustion and processes
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_industry`: Nitric oxide emissions from anthropogenic industrial combustion and processes
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_industry`: Formaldehyde emissions from anthropogenic industrial combustion and processes
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_rco`: Carbon monoxide emissions from anthropogenic residential, commercial, and others
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_rco`: Nitric oxide emissions from anthropogenic residential, commercial, and others
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_rco`: Formaldehyde emissions from anthropogenic residential, commercial, and others
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_shipping`: Carbon monoxide emissions from anthropogenic international shipping
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_shipping`: Nitric oxide emissions from anthropogenic international shipping
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_shipping`: Formaldehyde emissions from anthropogenic international shipping
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_solvents`: Carbon monoxide emissions from anthropogenic solvents
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_solvents`: Nitric oxide emissions from anthropogenic solvents
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_solvents`: Formaldehyde emissions from anthropogenic solvents
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_transportation`: Carbon monoxide emissions from anthropogenic surface transportation (road, rail, other)
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_transportation`: Nitric oxide emissions from anthropogenic surface transportation (road, rail, other)
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_transportation`: Formaldehyde emissions from anthropogenic surface transportation (road, rail, other)
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_co_due_to_anthropogenic_waste`: Carbon monoxide emissions from anthropogenic waste disposal and handling
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_no_due_to_anthropogenic_waste`: Nitric oxide emissions from anthropogenic waste disposal and handling
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `emissions_of_hcho_due_to_anthropogenic_waste`: Formaldehyde emissions from anthropogenic waste disposal and handling
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 ## Application-specific variables
 ### required framework-provided variables
 Required CCPP framework-provided variables
 * `ccpp_error_message`: Error message for error handling in CCPP
-    * `character(kind=len=512)`: units = none
+    * `character`: units = none
 * `ccpp_error_code`: Error code for error handling in CCPP
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 ### optional framework-provided variables
 Optional CCPP framework-provided variables
 * `ccpp_scheme_name`: CCPP physics scheme name
-    * `character(kind=len=64)`: units = none
+    * `character`: units = none
 * `ccpp_constituent_properties`: CCPP Constituent Properties
-    * `ccpp_constituent_prop_ptr_t(kind=)`: units = none
+    * `ccpp_constituent_prop_ptr_t`: units = none
 * `ccpp_constituents`: Array of constituents managed by CCPP Framework
-    * `real(kind=kind_phys)`: units = none
+    * `real`: units = none
 * `ccpp_constituent_min_values`: CCPP constituent minimum values
-    * `real(kind=kind_phys)`: units = none
+    * `real`: units = none
 * `number_of_ccpp_constituents`: Number of constituents managed by CCPP Framework
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `ccpp_block_count`: CCPP block count
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `ccpp_block_sizes`: CCPP block sizes
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `ccpp_thread_number`: Number of current OpenMP thread. This variable may only be used during CCPP run phase
     * `integer`: units = index
 ## system variables
 Variables related to the compute environment
 * `flag_for_mpi_root`: Flag for MPI root process
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `log_output_unit`: Fortran logical unit for output log file
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 ## GFS_typedefs_GFS_control_type
 * `sigma_pressure_hybrid_coordinate_a_coefficient`: Sigma pressure hybrid coordinate a coefficient
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `radiatively_active_gases_as_string`: Radiatively active gases as string
-    * `character(kind=len=128)`: units = none
+    * `character`: units = none
 * `aerosol_aware_multiplicative_rain_conversion_parameter_for_deep_convection`: Aerosol aware multiplicative rain conversion parameter for deep convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `aerosol_aware_multiplicative_rain_conversion_parameter_for_shallow_convection`: Aerosol aware multiplicative rain conversion parameter for shallow convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `number_of_microphysics_variables_in_xy_dimensioned_restart_array`: Number of microphysics variables in xy dimensioned restart array
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_microphysics_variables_in_xyz_dimensioned_restart_array`: Number of microphysics variables in xyz dimensioned restart array
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_random_numbers`: Number of random numbers
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `multiplicative_tuning_parameter_for_atmosphere_diffusivity`: Multiplicative tuning parameter for atmosphere diffusivity
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `atmosphere_heat_diffusivity_due_to_background`: Atmosphere heat diffusivity due to background
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `max_atmosphere_heat_diffusivity_due_to_background`: Maximum atmosphere heat diffusivity due to background
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `atmosphere_momentum_diffusivity_due_to_background`: Atmosphere momentum diffusivity due to background
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `sigma_pressure_hybrid_coordinate_b_coefficient`: Sigma pressure hybrid coordinate b coefficient
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `cellular_automata_finer_grid`: Cellular automata finer grid
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `cellular_automata_lifetime`: Cellular automata lifetime
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `cellular_automata_seed_frequency`: Cellular automata seed frequency
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `cellular_automata_seed_probability`: Cellular automata seed probability
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `identifier_for_2018_scale_aware_tke_moist_edmf_pbl`: Identifier for 2018 scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_scale_aware_tke_moist_edmf_pbl_scheme`: Control for scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_2019_scale_aware_tke_moist_edmf_pbl`: Identifier for 2019 scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `cloud_condensate_autoconversion_threshold_coefficient`: Cloud condensate autoconversion threshold coefficient
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `cloud_condensate_autoconversion_threshold_coefficient_for_deep_convection`: Cloud condensate autoconversion threshold coefficient for deep convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `control_for_cloud_area_fraction_option`: Control for cloud area fraction option
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `reciprocal_of_cloud_phase_transition_temperature_range`: Reciprocal of cloud phase transition temperature range
-    * `real(kind=kind_phys)`: units = K-1
+    * `real`: units = K-1
 * `cloud_phase_transition_threshold_temperature`: Cloud phase transition threshold temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `control_for_cloud_species_mixing_in_mynn_pbl_scheme`: Control for cloud species mixing in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_cloud_pdf_in_mynn_pbl_scheme`: Control for cloud probability density function in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `precipitation_evaporation_coefficient`: Precipitation evaporation coefficient
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `coefficient_for_variable_bulk_richardson_number_over_land`: Coefficient for variable bulk richardson number over land
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `coefficient_for_variable_bulk_richardson_number_over_water`: Coefficient for variable bulk richardson number over water
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `autoconversion_to_snow_coefficient`: Autoconversion to snow coefficient
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `autoconversion_to_snow_coefficient_for_deep_convection`: Autoconversion to snow coefficient for deep convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `autoconversion_to_rain_coefficient`: Autoconversion to rain coefficient
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `autoconversion_to_rain_coefficient_for_deep_convection`: Autoconversion to rain coefficient for deep convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `chemical_tracer_scavenging_fractions`: Chemical tracer scavenging fractions
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `cloud_condensate_detrainment_coefficient`: Cloud condensate detrainment coefficient
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `control_for_convective_cloud_diagnostics`: Control for convective cloud diagnostics
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `cosine_of_solar_declination_angle`: Cosine of solar declination angle
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `control_for_sgs_cloud_radiation_coupling_in_mynn_pbl_scheme`: Control for subgrid-scale cloud radiation coupling in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `tunable_parameter_for_critical_cloud_top_entrainment_instability_criteria`: Tunable parameter for critical cloud top entrainment instability criteria
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `critical_relative_humidity_at_top_of_atmosphere_boundary_layer`: Critical relative humidity at top of atmosphere boundary layer
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `critical_relative_humidity_at_surface`: Critical relative humidity at surface
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `critical_relative_humidity_at_toa`: Critical relative humidity at the top of the atmosphere
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `date_and_time_at_model_initialization_in_iso_order`: Date and time at model initialization in iso order
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `date_and_time_at_model_initialization_in_united_states_order`: Date and time at model initialization in united states order
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `decorrelation_length_used_by_overlap_method`: Decorrelation length used by overlap method
-    * `real(kind=kind_phys)`: units = km
+    * `real`: units = km
 * `density_of_fresh_water`: Density of fresh water
-    * `real(kind=kind_phys)`: units = kg m-3
+    * `real`: units = kg m-3
 * `depth_of_soil_layers`: Depth of soil layers
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `tunable_parameter_1_for_detrainment_and_precipitation_partitioning_in_chikira_sugiyama_deep_convection`: Tunable parameter 1 for detrainment and precipitation partitioning in chikira sugiyama deep convection
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `tunable_parameter_2_for_detrainment_and_precipitation_partitioning_in_chikira_sugiyama_deep_convection`: Tunable parameter 2 for detrainment and precipitation partitioning in chikira sugiyama deep convection
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `detrainment_conversion_parameter_for_deep_convection`: Detrainment conversion parameter for deep convection
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 * `detrainment_conversion_parameter_for_shallow_convection`: Detrainment conversion parameter for shallow convection
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 * `do_unified_gravity_wave_physics_diagnostics`: Do unified gravity wave physics diagnostics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_chemical_tracer_diagnostics`: Do chemical tracer diagnostics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `sigma_pressure_threshold_at_upper_extent_of_background_diffusion`: Sigma pressure threshold at upper extent of background diffusion
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `directory_for_rte_rrtmgp_source_code`: Directory for Radiative Transfer for Energetics/Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) source code
-    * `character(kind=len=128)`: units = none
+    * `character`: units = none
 * `do_myj_pbl_scheme`: Do Mellor-Yamada-Janjic planetary boundary layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_myj_surface_layer_scheme`: Do Mellor-Yamada-Janjic surface layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_mynn_pbl_scheme`: Do Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_mynn_surface_layer_scheme`: Do Mellor-Yamada-Nakanishi-Niino surface layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_unified_gravity_wave_physics_gwd_scheme`: Do Unifed Gravity Wave Physics gravity wave drag scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `downdraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme`: Downdraft area fraction in scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `downdraft_fraction_reaching_surface_over_land_for_deep_convection`: Downdraft fraction reaching surface over land for deep convection
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `downdraft_fraction_reaching_surface_over_water_for_deep_convection`: Downdraft fraction reaching surface over water for deep convection
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `control_for_edmf_in_mynn_pbl_scheme`: Control for eddy-diffusivity mass flux in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_edmf_momentum_transport_in_mynn_pbl_scheme`: Control for eddy-diffusivity mass flux momentum transport in Mellor-Yamada-Nakanishi-Niino surface layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_edmf_partitioning_in_mynn_pbl_scheme`: Control for eddy-diffusivity mass flux partitioning in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_edmf_tke_transport_in_mynn_pbl_scheme`: Control for eddy-diffusivity mass flux turbulent kinetic energy transport in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `surface_layer_scheme_enthalpy_flux_factor`: Surface layer scheme enthalpy flux factor
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `tunable_parameter_for_entrainment_efficiency_in_chikira_sugiyama_deep_convection`: Tunable parameter for entrainment efficiency in chikira sugiyama deep convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `entrainment_rate_coefficient_for_deep_convection`: Entrainment rate coefficient for deep convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `entrainment_rate_coefficient_for_shallow_convection`: Entrainment rate coefficient for shallow convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `equation_of_time`: Equation of time
-    * `real(kind=kind_phys)`: units = radian
+    * `real`: units = radian
 * `relative_humidity_threshold_for_condensation`: Relative humidity threshold for condensation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `do_arakawa_wu_downdrafts_for_deep_convection`: Do arakawa wu downdrafts for deep convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_debug_output`: Do debug output
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_diagnostics`: Do diagnostics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_xyz_dimensioned_diagnostics`: Do xyz dimensioned diagnostics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_flip`: Do flip
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_flux_adjusting_surface_data_assimilation_system`: Control for flux adjusting surface data assimilation system
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_flux_form_in_chikira_sugiyama_deep_convection_scheme`: Do flux form in chikira sugiyama deep convection scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_nrl_2015_ozone_scheme`: Do Naval Research Laboratory 2015 ozone scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_prescribed_aerosols`: Do prescribed aerosols
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_aerosol_physics`: Do aerosol physics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_arakawa_wu_adjustment`: Do arakawa wu adjustment
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_canopy_heat_storage_in_land_surface_scheme`: Do canopy heat storage in land surface scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_canopy_stomatal_resistance`: Control for land surface scheme canopy stomatal resistance
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_cellular_automata`: Do cellular automata
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_chemistry_coupling`: Do chemistry coupling
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_chikira_sugiyama_deep_convection_scheme`: Do chikira sugiyama deep convection scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_in_cloud_condensate`: Do in cloud condensate
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_cloud_effective_radii`: Do cloud effective radii
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_cloud_overlap_method_for_radiation`: Control for cloud overlap method for radiation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_constant_decorrelation_length_method`: Identifier for constant decorrelation length method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_convective_gwd`: Do convective gravity wave drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_convective_transport_of_tracers`: Do convective transport of tracers
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_converting_hydrometeors_from_moist_to_dry_air`: Do converting hydrometeors from moist to dry air
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_crick_elimination`: Do crick elimination
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_decorrelation_length_cloud_overlap_method`: Identifier for decorrelation length cloud overlap method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_decorrelation_length_method`: Control for decorrelation length method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_shortwave_radiation_aerosols`: Control for shortwave radiation aerosols
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_land_surface_scheme_dynamic_vegetation`: Control for land surface scheme dynamic vegetation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_exponential_cloud_overlap_method`: Identifier for exponential cloud overlap method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_exponential_random_cloud_overlap_method`: Identifier for exponential random cloud overlap method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_fer_hires_microphysics_scheme`: Identifier for fer hires microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `is_first_timestep`: Is first timestep
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_surface_flux_coupling`: Do surface flux coupling
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_fractional_landmask`: Do fractional landmask
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_frozen_soil_permeability`: Control for land surface scheme frozen soil permeability
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_cellular_automata_gaussian_spatial_filter`: Do cellular automata gaussian spatial filter
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_gcycle_surface_option`: Do gcycle surface option
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_generic_tendency_due_to_deep_convection`: Do generic tendency due to deep convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_generic_tendency_due_to_gwd`: Do generic tendency due to gravity wave drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_generic_tendency_due_to_pbl`: Do generic tendency due to planetary boundary layer
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_generic_tendency_due_to_shallow_convection`: Do generic tendency due to shallow convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_grell_freitas_deep_convection`: Identifier for grell freitas deep convection
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_grell_freitas_shallow_convection`: Identifier for grell freitas shallow convection
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_gfdl_microphysics_radiation_interaction`: Do Geophysical Fluid Dynamics Laboratory microphysics radiation interaction
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_gfdl_microphysics_scheme`: Identifier for Geophysical Fluid Dynamics Laboratory microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_global_cellular_automata`: Do global cellular automata
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_global_cellular_automata_closure`: Do global cellular automata closure
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_global_cellular_automata_deep_convective_entrainment`: Do global cellular automata deep convective entrainment
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_global_cellular_automata_trigger`: Do global cellular automata trigger
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_gwd`: Do gravity wave drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_surface_snow_albedo`: Control for land surface scheme surface snow albedo
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_gsl_drag_suite_large_scale_orographic_and_blocking_drag`: Do Global Systems Lab drag suite large-scale orographic and blocking drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_gsl_drag_suite_small_scale_orographic_drag`: Do Global Systems Lab drag suite small-scale orographic drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_gsl_drag_suite_turbulent_orographic_form_drag`: Do Global Systems Lab drag suite turbulent orographic form drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_hybrid_edmf_pbl_scheme`: Do hybrid eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_hogan_decorrelation_length_method`: Identifier for hogan decorrelation length method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_hurricane_specific_code_in_scale_aware_mass_flux_deep_convection`: Do hurricane specific code in scale aware mass flux deep convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_hurricane_specific_code_in_scale_aware_mass_flux_shallow_convection`: Do hurricane specific code in scale aware mass flux shallow convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_hydrostatic_solver`: Do hydrostatic solver
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_ice_cloud_condensation_nuclei_forcing`: Control for ice cloud condensation nuclei forcing
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_separate_advection_of_condensate_species`: Do separate advection of condensate species
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_initial_time_date`: Control for initial time date
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_lake_surface_scheme`: Control for lake surface scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_land_surface_scheme`: Control for land surface scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_cloud_area_fraction_option_for_radiation`: Do cloud area fraction option for radiation
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_lower_boundary_soil_temperature`: Control for land surface scheme lower boundary soil temperature
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_lw_clouds_subgrid_approximation`: Control for lw clouds subgrid approximation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_deep_convection_scheme`: Control for deep convection scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_shallow_convection_scheme`: Control for shallow convection scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_max_cloud_overlap_method`: Control for maximum cloud overlap method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_max_random_cloud_overlap_method`: Identifier for maximum random cloud overlap method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_microphysics_scheme`: Control for microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_moorthi_stratus`: Do moorthi stratus
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_morrison_gettelman_microphysics_scheme`: Identifier for morrison gettelman microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_mountain_blocking_for_sppt`: Do mountain blocking for stochastically perturbed physics tendencies
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_noah_land_surface_scheme`: Identifier for noah land surface scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_noah_lsm_ua_extension`: Do Noah land surface model University of Arizona extension
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_noah_wrfv4_land_surface_scheme`: Identifier for noah wrfv4 land surface scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_noahmp`: Identifier for Noah land surface model with multiparameterization options
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_nsstm_analysis_in_gcycle`: Do GFS near-surface sea temperature scheme analysis in gcycle
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_nsstm`: Control for GFS near-surface sea temperature scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_new_tiedtke_deep_convection`: Identifier for new tiedtke deep convection
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_new_tiedtke_shallow_convection`: Identifier for new tiedtke shallow convection
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_surface_layer_scheme_ocean_currents`: Do surface layer scheme ocean currents
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_old_pbl_scheme`: Do old pbl scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_optical_property_for_ice_clouds_for_longwave_radiation`: Control for optical property for ice clouds for longwave radiation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_optical_property_for_ice_clouds_for_shortwave_radiation`: Control for optical property for ice clouds for shortwave radiation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_optical_property_for_liquid_clouds_for_longwave_radiation`: Control for optical property for liquid clouds for longwave radiation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_optical_property_for_liquid_clouds_for_shortwave_radiation`: Control for optical property for liquid clouds for shortwave radiation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_oreopoulos_decorrelation_length_method`: Identifier for oreopoulos decorrelation length method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_output_of_tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep_assuming_clear_sky`: Do output of tendency of air temperature due to longwave heating on radiation timestep assuming clear sky
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_output_of_tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep_assuming_clear_sky`: Do output of tendency of air temperature due to shortwave heating on radiation timestep assuming clear sky
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_nrl_2006_ozone_scheme`: Do Naval Research Laboratory 2006 ozone scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_pdf_shape_for_microphysics`: Control for probability density function shape for microphysics
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_surface_layer_scheme_surface_drag_coefficient_for_momentum_in_air_perturbations`: Do surface layer scheme surface drag coefficient for momentum in air perturbations
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `disable_precipitation_radiative_effect`: Disable precipitation radiative effect
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_precipitation_type_partition`: Control for land surface scheme precipitation type partition
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_dominant_precipitation_type_partition`: Do dominant precipitation type partition
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_radar_reflectivity`: Do radar reflectivity
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_radiative_transfer`: Control for land surface scheme radiative transfer
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_random_cloud_overlap_method`: Identifier for random cloud overlap method
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_random_clouds_in_relaxed_arakawa_schubert_deep_convection`: Do random clouds in relaxed arakawa schubert deep convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_relaxed_arakawa_schubert_deep_convection`: Do relaxed arakawa schubert deep convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_read_leaf_area_index_from_input`: Do read leaf area index from input
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_read_surface_albedo_for_diffused_shortwave_from_input`: Do read surface albedo for diffused shortwave from input
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_limited_roughness_length_over_ocean`: Do limited surface roughness length over ocean
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_reference_pressure_theta`: Do reference pressure theta
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `is_restart`: Is restart
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_rrtmgp_radiation_scheme`: Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) radiation scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_ruc_land_surface_scheme`: Identifier for Rapid Update Cycle land surface scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_land_surface_scheme_runoff_and_groundwater`: Control for land surface scheme runoff and groundwater
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_scale_aware_mass_flux_deep_convection`: Identifier for scale aware mass flux deep convection
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_scale_aware_mass_flux_shallow_convection`: Identifier for scale aware mass flux shallow convection
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_sas_deep_convection`: Identifier for Simplified Arakawa-Schubert deep convection scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_sas_shallow_convection`: Identifier for Simplified Arakawa-Schubert shallow convection scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_scale_aware_mass_flux_deep_convection`: Do scale aware mass flux deep convection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_scale_aware_shin_hong_pbl_scheme`: Do scale aware shin hong pbl scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_scale_aware_tke_moist_edmf_pbl`: Do scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_sgs_cellular_automata`: Do sgs cellular automata
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_sas_shallow_convection`: Do Simplified Arakawa-Schubert shallow convection scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_shoc`: Do Simplified Higher-Order Closure stochastic physics scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_shoc_after_convection`: Do Simplified Higher-Order Closure stochastic physics scheme after convection parameterization
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_soil_and_snow_temperature_time_integration`: Control for land surface scheme soil and snow temperature time integration
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_land_surface_scheme_soil_moisture_factor_stomatal_resistance`: Control for land surface scheme soil moisture factor stomatal resistance
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_solar_constant`: Control for solar constant
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_stochastic_cloud_fraction_perturbations`: Do stochastic cloud fraction perturbations
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_stochastic_microphysics_perturbations`: Do stochastic microphysics perturbations
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_stochastic_physics_perturbations`: Do stochastic physics perturbations
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_stochastic_radiative_heating_perturbations`: Do stochastic radiative heating perturbations
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_stochastic_shum_option`: Do Stochastic HUMidity stochastic physics option
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_stochastic_skeb_option`: Do Stochastic Kinetic Energy Backscatter option
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_stratospheric_water_vapor_physics`: Do stratospheric water vapor physics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_land_surface_scheme_supercooled_liquid_water`: Control for land surface scheme supercooled liquid water
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_surface_emissivity`: Control for surface emissivity
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_land_surface_scheme_surface_layer_drag_coefficient`: Control for land surface scheme surface layer drag coefficient
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_surface_roughness_option_over_water`: Control for surface roughness option over water
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_sw_clouds_subgrid_approximation`: Control for sw clouds subgrid approximation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_land_surface_scheme_thermal_conductivity_option`: Control for land surface scheme thermal conductivity option
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_thompson_microphysics_scheme`: Identifier for thompson microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_ugwp_version_0`: Do Unified Gravity Wave Physics version 0
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_ugwp_version_0_nonorographic_gwd`: Do Unified Gravity Wave Physics version 0 non-orographic gravity wave drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_ugwp_version_0_orographic_gwd`: Do Unified Gravity Wave Physics version 0 orographic gravity wave drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_ugwp_version_1`: Do Unified Gravity Wave Physics version 1
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_ugwp_version_1_nonorographic_gwd`: Do Unified Gravity Wave Physics version 1 non-orographic gravity wave drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_ugwp_version_1_orographic_gwd`: Do Unified Gravity Wave Physics version 1 orographic gravity wave drag
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_shoc_cloud_area_fraction_for_radiation`: Do Simplified Higher-Order Closure stochastic physics scheme cloud area fraction for radiation
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_surface_layer_scheme_skin_temperature_update`: Control for surface layer scheme skin temperature update
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_surface_albedo`: Control for surface albedo
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_prescribed_co2`: Control for prescribed co2
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_vertical_index_direction`: Control for vertical index direction
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_ocean_wave_coupling`: Do ocean wave coupling
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_one_way_ocean_wave_coupling_to_atmosphere`: Do one way ocean wave coupling to atmosphere
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_wsm6_microphysics_scheme`: Identifier for wsm6 microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_ysu_pbl_scheme`: Do Yonsei University (YSU) planetary boundary layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `identifier_for_zhao_carr_microphysics_scheme`: Identifier for zhao carr microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `identifier_for_zhao_carr_pdf_microphysics_scheme`: Identifier for Zhao-Carr probability density function microphysics scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `do_hurricane_specific_code_in_hybrid_edmf_pbl_scheme`: Do hurricane-specific code in hybrid eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_integrated_dynamics_through_earths_atmosphere`: Do integrated dynamics through earths atmosphere
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_print`: Do print
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_save_shallow_convective_cloud_area_fraction`: Do save shallow convective cloud area fraction
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_tke_dissipation_heating`: Do tke dissipation heating
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_call_longwave_radiation`: Do call longwave radiation
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_rrtmg_cloud_optics`: Flag for Rapid Radiative Transfer Model for General circulation model applications (RRTMG) cloud optics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_rrtmgp_cloud_optics_lookup_table`: Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) cloud optics lookup table
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_rrtmgp_cloud_optics_with_pade_approximation`: Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) with Pade approximation
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_rrtmgp_longwave_jacobian`: Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave jacobian
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_call_shortwave_radiation`: Do call shortwave radiation
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_longwave_scattering_in_cloud_optics`: Do longwave scattering in cloud optics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_tracer_xyz_dimensioned_diagnostics`: Do tracer xyz dimensioned diagnostics
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_variable_bulk_richardson_number`: Control for variable bulk richardson number
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `date_and_time_of_forecast_in_united_states_order`: Date and time of forecast in united states order
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `forecast_utc_hour`: Forecast utc hour
-    * `real(kind=kind_phys)`: units = h
+    * `real`: units = h
 * `forecast_time`: Forecast time
-    * `real(kind=kind_phys)`: units = h
+    * `real`: units = h
 * `forecast_time_on_previous_timestep`: Forecast time on previous timestep
-    * `real(kind=kind_phys)`: units = h
+    * `real`: units = h
 * `period_of_longwave_radiation_calls`: Period of longwave radiation calls
-    * `real(kind=kind_phys)`: units = s
+    * `real`: units = s
 * `period_of_shortwave_radiation_calls`: Period of shortwave radiation calls
-    * `real(kind=kind_phys)`: units = s
+    * `real`: units = s
 * `all_ice_cloud_threshold_temperature`: All ice cloud threshold temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `control_for_gravitational_settling_of_cloud_droplets`: Control for gravitational settling of cloud droplets
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_drag_suite_gwd`: Control for drag option in gravity wave drag scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `horizontal_loop_extent`: Horizontal loop extent
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `period_of_diagnostics_reset`: Period of diagnostics reset
-    * `real(kind=kind_phys)`: units = h
+    * `real`: units = h
 * `tunable_parameter_for_ice_supersaturation`: Tunable parameter for ice supersaturation
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `index_of_ice_vegetation_category`: Index of ice vegetation category
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `vertical_dimension_of_sea_ice`: Vertical dimension of sea ice
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `index_of_air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of air temperature on previous timestep in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of air temperature two timesteps back in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array`: Index of nonconvective cloud area fraction in atmosphere layer in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of nonconvective cloud area fraction in atmosphere layer in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array`: Index of cloud liquid water effective radius in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_convective_cloud_area_fraction_in_xyz_dimensioned_restart_array`: Index of convective cloud area fraction in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_convective_cloud_condensate_mixing_ratio_wrt_moist_air_in_xyz_dimensioned_restart_array`: Index of convective cloud condensate mass mixing ratio with respect to moist air in the XYZ-dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_horizontal_gridpoint_for_debug_output`: Index of horizontal gridpoint for debug output
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_first_chemical_tracer_in_tracer_concentration_array`: Index of first chemical tracer in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_graupel_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of graupel mass mixing ratio with respect to moist air in the tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_graupel_effective_radius_in_xyz_dimensioned_restart_array`: Index of graupel effective radius in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array`: Index of mass number concentration of graupel in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_cloud_ice_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of cloud ice mass mixing ratio with respect to moist air in the tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array`: Index of mass number concentration of cloud ice in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_cloud_ice_effective_radius_in_xyz_dimensioned_restart_array`: Index of cloud ice effective radius in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array`: Index of mass number concentration of nonhygroscopic ice nucleating aerosols in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of cloud liquid water mass mixing ratio with respect to moist air in the tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array`: Index of mass number concentration of cloud droplets in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_weighted_rime_factor_in_tracer_concentration_array`: Index of mass weighted rime factor in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_ozone_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of ozone mass mixing ratio with respect to moist air in the tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_rain_effective_radius_in_xyz_dimensioned_restart_array`: Index of rain effective radius in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_number_concentration_of_rain_in_tracer_concentration_array`: Index of mass number concentration of rain in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_rain_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of rain mass mixing ratio with respect to moist air in the tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_snow_effective_radius_in_xyz_dimensioned_restart_array`: Index of snow effective radius in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_number_concentration_of_snow_in_tracer_concentration_array`: Index of mass number concentration of snow in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of snow mass mixing ratio with respect to moist air in the tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back_in_xyz_dimensioned_restart_array`: Index of specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `control_for_stochastic_land_surface_perturbation`: Control for stochastic land surface perturbation
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `index_of_air_pressure_at_surface_on_previous_timestep_in_xyz_dimensioned_restart_array`: Index of air pressure at surface on previous timestep in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_air_pressure_at_surface_two_timesteps_back_in_xyz_dimensioned_tracer_array`: Index of air pressure at surface two timesteps back in xyz dimensioned tracer array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convectionin_in_xy_dimensioned_restart_array`: Index of enhancement to wind speed at surface adjacent layer due to convectionin in xy dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_tke_in_tracer_concentration_array`: Index of turbulent kinetic energy in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array`: Index of mass number concentration of hygroscopic aerosols in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_water_vapor_mixing_ratio_wrt_moist_air_in_tracer_concentration_array`: Index of specific humidity (water vapor mass mixing ratio with respect to moist air) in tracer concentration array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array`: Index of atmosphere heat diffusivity in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_upward_virtual_potential_temperature_flux_in_xyz_dimensioned_restart_array`: Index of upward virtual potential temperature flux in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_subgrid_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array`: Index of subgrid cloud area fraction in atmosphere layer in xyz dimensioned restart array
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `index_of_timestep`: Index of timestep
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `reciprocal_of_grid_scale_range`: Reciprocal of grid scale range
-    * `real(kind=kind_phys)`: units = rad2 m-2
+    * `real`: units = rad2 m-2
 * `iounit_of_log`: Iounit of log
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `iounit_of_namelist`: Iounit of namelist
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `forecast_julian_day`: Forecast julian day
-    * `real(kind=kind_phys)`: units = days
+    * `real`: units = days
 * `min_lake_ice_area_fraction`: Min lake ice area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `multiplicative_tuning_parameter_for_reduced_latent_heat_flux_due_to_canopy_heat_storage`: Multiplicative tuning parameter for reduced latent heat flux due to canopy heat storage
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `max_tendency_of_potential_temperature_of_air_due_to_large_scale_precipitation`: Maximum tendency of air potential temperature due to large-scale precipitation
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `lower_bound_of_vertical_dimension_of_surface_snow`: Lower bound of vertical dimension of surface snow
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `land_surface_perturbation_magnitudes`: Land surface perturbation magnitudes
-    * `real(kind=kind_phys)`: units = variable
+    * `real`: units = variable
 * `max_critical_relative_humidity`: Maximum critical relative humidity
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `max_grid_scale`: Maximum grid scale
-    * `real(kind=kind_phys)`: units = m2 rad-2
+    * `real`: units = m2 rad-2
 * `max_soil_moisture_content_for_lsm`: Maximum soil moisture content for land surface model
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `do_allow_supersaturation_after_sedimentation`: Do allow supersaturation after sedimentation
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `autoconversion_to_snow_size_threshold`: Autoconversion to snow size threshold
-    * `real(kind=kind_phys)`: units = um
+    * `real`: units = um
 * `bergeron_findeisen_process_efficiency_factor`: Bergeron findeisen process efficiency factor
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `relative_variance_of_subgrid_cloud_condensate_distribution`: Relative variance of subgrid cloud condensate distribution
-    * `real(kind=kind_phys)`: units = kg2 kg-2
+    * `real`: units = kg2 kg-2
 * `prescribed_number_concentration_of_cloud_droplets`: Prescribed number concentration of cloud droplets
-    * `real(kind=kind_phys)`: units = m-3
+    * `real`: units = m-3
 * `do_prescribed_number_concentration_of_cloud_droplets`: Do prescribed number concentration of cloud droplets
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_cloud_ice_processes`: Do cloud ice processes
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_gmao_autoconversion_to_snow`: Do gmao autoconversion to snow
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_graupel_instead_of_hail`: Do graupel instead of hail
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_hail_instead_of_graupel`: Do hail instead of graupel
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_heterogeneous_nucleation`: Do heterogeneous nucleation
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_liu_autoconversion_to_rain`: Do liu autoconversion to rain
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_seifert_and_beheng_2001_autoconversion`: Do seifert and beheng 2001 autoconversion
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_uniform_subcolumns`: Do uniform subcolumns
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_prescribed_number_concentration_of_graupel`: Do prescribed number concentration of graupel
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `do_prescribed_number_concentration_of_cloud_ice`: Do prescribed number concentration of cloud ice
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `prescribed_number_concentration_of_graupel`: Prescribed number concentration of graupel
-    * `real(kind=kind_phys)`: units = m-3
+    * `real`: units = m-3
 * `prescribed_number_concentration_of_cloud_ice`: Prescribed number concentration of cloud ice
-    * `real(kind=kind_phys)`: units = m-3
+    * `real`: units = m-3
 * `min_cloud_condensate_mixing_ratio_wrt_moist_air_threshold`: Minimum threshold cloud condensate mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `min_cloud_liquid_water_mixing_ratio_wrt_moist_air_threshold`: Minimum threshold cloud liquid water mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `min_cloud_ice_mixing_ratio_wrt_moist_air_threshold`: Minimum threshold cloud ice mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `relative_humidity_threshold_for_ice_nucleation`: Relative humidity threshold for ice nucleation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `timescale_for_autoconversion_to_snow`: Timescale for autoconversion to snow
-    * `real(kind=kind_phys)`: units = s
+    * `real`: units = s
 * `alpha_tuning_coefficient_for_morrison_gettelman_microphysics_scheme`: Alpha tuning coefficient for morrison gettelman microphysics scheme
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `control_for_precipitation_area_fraction_method`: Control for precipitation area fraction method
-    * `character(kind=len=16)`: units = none
+    * `character`: units = none
 * `min_large_ice_fraction`: Minimum large ice fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `min_pressure_in_rrtmgp`: Minimum pressure in Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP)
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `min_grid_scale`: Min grid scale
-    * `real(kind=kind_phys)`: units = m2 rad-2
+    * `real`: units = m2 rad-2
 * `min_soil_moisture_content_for_lsm`: Minimum soil moisture content for land surface model
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `min_temperature_in_rrtmgp`: Minimum temperature in Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP)
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `control_for_total_water_mixing_in_mynn_pbl_scheme`: Control for total water mixing in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_mixing_length_in_mynn_pbl_scheme`: Control for mixing length in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `momentum_transport_reduction_factor_due_to_pressure_gradient_force_for_deep_convection`: Momentum transport reduction factor due to pressure gradient force for deep convection
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `momentum_transport_reduction_factor_due_to_pressure_gradient_force_for_shallow_convection`: Momentum transport reduction factor due to pressure gradient force for shallow convection
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `mpi_communicator`: Mpi communicator
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `mpi_rank`: Mpi rank
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `mpi_root`: Mpi root
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `number_of_mpi_tasks`: Number of mpi tasks
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `tunable_parameter_for_critical_cloud_workfunction_in_relaxed_arakawa_schubert_deep_convection`: Tunable parameter for critical cloud workfunction in relaxed arakawa schubert deep convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `tunable_parameters_for_convective_gwd`: Tunable parameters for convective gravity wave drag
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `multiplicative_tunable_parameters_for_mountain_blocking_and_orographic_gwd`: Multiplicative tunable parameters for mountain blocking and orographic gravity wave drag
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `control_for_additional_diagnostics_in_mynn_pbl_scheme`: Control for additional diagnostics in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `filename_of_namelist`: Filename of namelist
-    * `character(kind=len=64)`: units = none
+    * `character`: units = none
 * `filename_of_internal_namelist`: Filename of internal namelist
-    * `character(kind=len=256)`: units = none
+    * `character`: units = none
 * `number_of_xy_dimensioned_auxiliary_arrays`: Number of xy dimensioned auxiliary arrays
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_pdf_based_variables_in_xyz_dimensioned_restart_array`: Number of probability density function-based variables in XYZ-dimensioned restart array
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_xyz_dimensioned_auxiliary_arrays`: Number of xyz dimensioned auxiliary arrays
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_radiatively_active_gases`: Number of radiatively active gases
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_aerosol_tracers`: Number of aerosol tracers
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_gaussian_quadrature_angles_for_radiation`: Number of gaussian quadrature angles for radiation
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_chemical_tracers`: Number of chemical tracers
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_condensate_species`: Number of condensate species
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_cloud_types_in_chikira_sugiyama_deep_convection`: Number of cloud types in chikira sugiyama deep convection
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_convective_cloud_variables_in_xyz_dimensioned_restart_array`: Number of convective cloud variables in xyz dimensioned restart array
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_days_in_current_year`: Number of days in current year
-    * `integer(kind=)`: units = days
+    * `integer`: units = days
 * `number_of_equatorial_longitude_points`: Number of equatorial longitude points
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_variables_in_xy_dimensioned_restart_array`: Number of variables in xy dimensioned restart array
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_variables_in_xyz_dimensioned_restart_array`: Number of variables in xyz dimensioned restart array
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_frozen_precipitation_species`: Number of frozen precipitation species
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_hydrometeors`: Number of hydrometeors
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_independent_cellular_automata`: Number of independent cellular automata
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_iterations_to_spin_up_cellular_automata`: Number of iterations to spin up cellular automata
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_perturbed_land_surface_variables`: Number of perturbed land surface variables
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_latitude_points`: Number of latitude points
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_lines_in_internal_namelist`: Number of lines in internal namelist
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_longwave_bands`: Number of longwave bands
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_longwave_spectral_points`: Number of longwave spectral points
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_x_points_for_current_cubed_sphere_tile`: Number of x points for current cubed sphere tile
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_x_points_for_current_mpi_rank`: Number of x points for current mpi rank
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_y_points_for_current_cubed_sphere_tile`: Number of y points for current cubed sphere tile
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_y_points_for_current_mpi_rank`: Number of y points for current mpi rank
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_diagnostics_variables_for_radiation`: Number of diagnostics variables for radiation
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_ice_roughness_categories`: Number of ice roughness categories
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_spectral_wave_truncation_for_sas_convection`: Number of spectral wave truncation for Simplified Arakawa-Schubert deep convection scheme
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_statistical_measures_of_subgrid_orography`: Number of statistical measures of subgrid orography
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_shortwave_bands`: Number of shortwave bands
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_shortwave_spectral_points`: Number of shortwave spectral points
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `index_of_cubed_sphere_tile`: Index of cubed sphere tile
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `number_of_timesteps_between_diagnostics_resetting`: Number of timesteps between diagnostics resetting
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_timesteps_between_longwave_radiation_calls`: Number of timesteps between longwave radiation calls
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_timesteps_between_shortwave_radiation_calls`: Number of timesteps between shortwave radiation calls
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_timesteps_between_surface_cycling_calls`: Number of timesteps between surface cycling calls
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_timesteps_for_concurrent_radiation_and_remainder_physics_calls_after_model_initialization`: Number of timesteps for concurrent radiation and remainder physics calls after model initialization
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `number_of_tracers_plus_one`: Number of tracers plus one
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `vertical_dimension_for_radiation`: Vertical dimension for radiation
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `vertical_interface_dimension_for_radiation`: Vertical interface dimension for radiation
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `multiplicative_tuning_parameter_for_potential_evaporation`: Multiplicative tuning parameter for potential evaporation
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `air_pressure_at_bottom_extent_of_rayleigh_damping`: Air pressure at bottom extent of rayleigh damping
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `rain_conversion_parameter_for_deep_convection`: Rain conversion parameter for deep convection
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 * `rain_conversion_parameter_for_shallow_convection`: Rain conversion parameter for shallow convection
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 * `rain_evaporation_coefficient_over_ocean_for_deep_convection`: Rain evaporation coefficient over ocean for deep convection
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `rain_evaporation_coefficient_over_land_for_deep_convection`: Rain evaporation coefficient over land for deep convection
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `filename_of_rrtmgp_longwave_cloud_optics_coefficients`: File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave cloud optics coefficients
-    * `character(kind=len=128)`: units = none
+    * `character`: units = none
 * `filename_of_rrtmgp_shortwave_cloud_optics_coefficients`: File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) shortwave cloud optics coefficients
-    * `character(kind=len=128)`: units = none
+    * `character`: units = none
 * `filename_of_rrtmgp_longwave_k_distribution`: File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave k-distribution
-    * `character(kind=len=128)`: units = none
+    * `character`: units = none
 * `filename_of_rrtmgp_shortwave_k_distribution`: File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) shortwave k-distribution
-    * `character(kind=len=128)`: units = none
+    * `character`: units = none
 * `do_rrtmgp_shortwave_and_rrtmg_longwave_radiation`: Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) shortwave and Rapid Radiative Transfer Model for global climate model (GCM) applications (RRTMG) longwave radiation schemes
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `min_sea_ice_area_fraction`: Min sea ice area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `forecast_time_in_seconds`: Forecast time in seconds
-    * `real(kind=kind_phys)`: units = s
+    * `real`: units = s
 * `random_number_seed_for_cellular_automata`: Random number seed for cellular automata
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `random_number_seed_for_deep_convection`: Random number seed for deep convection
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `control_for_tke_dissipation_method`: Control for tke dissipation method
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `uncentering_coefficient_for_implicit_tke_integration`: Uncentering coefficient for implicit tke integration
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `pressure_threshold_for_increased_tke_dissipation`: Pressure threshold for increased tke dissipation
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `multiplicative_tunable_parameter_for_tke_dissipation`: Multiplicative tunable parameter for tke dissipation
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `multiplicative_tunable_parameter_for_tke_dissipation_at_surface_adjacent_layer`: Multiplicative tunable parameter for tke dissipation at surface adjacent layer
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `sine_of_solar_declination_angle`: Sine of solar declination angle
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `vertical_dimension_of_surface_snow`: Vertical dimension of surface snow
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `control_for_soil_type_dataset`: Control for soil type dataset
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `vertical_dimension_of_soil`: Vertical dimension of soil
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `vertical_dimension_of_soil_internal_to_land_surface_scheme`: Vertical dimension of soil internal to land surface scheme
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `solar_constant`: Solar constant
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `starting_x_index_for_current_mpi_rank`: Starting x index for current mpi rank
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `starting_y_index_for_current_mpi_rank`: Starting y index for current mpi rank
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `multiplicative_tuning_parameter_for_reduced_surface_heat_fluxes_due_to_canopy_heat_storage`: Multiplicative tuning parameter for reduced surface heat fluxes due to canopy heat storage
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `thickness_of_soil_layers_for_lsm`: Thickness of soil layers for land surface model
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `cellular_automata_vertical_velocity_perturbation_threshold_for_deep_convection`: Cellular automata vertical velocity perturbation threshold for deep convection
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `period_of_max_diagnostics_reset`: Period of maximum diagnostics reset
-    * `real(kind=kind_phys)`: units = s
+    * `real`: units = s
 * `timescale_for_rayleigh_damping`: Timescale for rayleigh damping
-    * `real(kind=kind_phys)`: units = d
+    * `real`: units = d
 * `time_elapsed_since_diagnostics_reset`: Time elapsed since diagnostics reset
-    * `real(kind=kind_phys)`: units = h
+    * `real`: units = h
 * `timestep_for_dynamics`: Timestep for dynamics
-    * `real(kind=kind_phys)`: units = s
+    * `real`: units = s
 * `do_tke_advection`: Do tke advection
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `control_for_tke_budget_output`: Control for tke budget output
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `multiplicative_tuning_parameter_for_tke_dissipative_heating`: Multiplicative tuning parameter for tke dissipative heating
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `total_amplitude_of_sppt_perturbation`: Total amplitude of stochastically perturbed physics tendencies perturbation
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `do_turbulent_orographic_form_drag_in_unified_gravity_wave_physics_gwd_scheme`: Do turbulent orographic form drag in Unified Gravity Wave Physics gravity wave drag scheme
-    * `logical(kind=)`: units = flag
+    * `logical`: units = flag
 * `updraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme`: Updraft area fraction in scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `tunable_parameter_1_for_max_cloud_base_updraft_velocity_in_chikira_sugiyama_deep_convection`: Tunable parameter 1 for max cloud base updraft velocity in chikira sugiyama deep convection
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `tunable_parameter_2_for_max_cloud_base_updraft_velocity_in_chikira_sugiyama_deep_convection`: Tunable parameter 2 for max cloud base updraft velocity in chikira sugiyama deep convection
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `upper_bound_of_vertical_dimension_of_surface_snow`: Upper bound of vertical dimension of surface snow
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `index_of_urban_vegetation_category`: Index of urban vegetation category
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `land_surface_perturbation_variables`: Land surface perturbation variables
-    * `character(kind=len=3)`: units = none
+    * `character`: units = none
 * `control_for_vegetation_dataset`: Control for vegetation dataset
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `vertical_layer_dimension_minus_one`: Vertical layer dimension minus one
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `sigma_pressure_hybrid_vertical_coordinate`: Sigma pressure hybrid vertical coordinate
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `lower_bound_for_depth_of_sea_temperature_for_nsstm`: Lower bound for depth of sea temperature for GFS near-surface sea temperature scheme
-    * `integer(kind=)`: units = mm
+    * `integer`: units = mm
 * `upper_bound_for_depth_of_sea_temperature_for_nsstm`: Upper bound for depth of sea temperature for GFS near-surface sea temperature scheme
-    * `integer(kind=)`: units = mm
+    * `integer`: units = mm
 * `index_of_water_vegetation_category`: Index of water vegetation category
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `filename_of_micm_configuration`: Filename of micm configuration
-    * `character(kind=len=*)`: units = none
+    * `character`: units = none
 ## GFS_typedefs_GFS_interstitial_type
 * `cloud_ice_mixing_ratio_wrt_moist_air_interstitial`: Cloud ice mass mixing ratio with respect to moist air in interstitial scheme
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_interstitial`: Cloud liquid water mass mixing ratio with respect to moist air in interstitial scheme
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `radiatively_active_gases`: Radiatively active gases
-    * `character(kind=len=128)`: units = none
+    * `character`: units = none
 * `process_split_cumulative_tendency_of_air_temperature`: Process split cumulative tendency of air temperature
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_liquid_water_particles_in_air`: Process split cumulative tendency of mass number concentration of cloud liquid water particles in air
-    * `real(kind=kind_phys)`: units = kg-1 s-1
+    * `real`: units = kg-1 s-1
 * `process_split_cumulative_tendency_of_graupel_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the graupel mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the cloud ice mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols`: Process split cumulative tendency of mass number concentration of nonhygroscopic ice nucleating aerosols
-    * `real(kind=kind_phys)`: units = kg-1 s-1
+    * `real`: units = kg-1 s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_air`: Process split cumulative tendency of mass number concentration of cloud ice water crystals in air
-    * `real(kind=kind_phys)`: units = kg-1 s-1
+    * `real`: units = kg-1 s-1
 * `process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the cloud liquid water mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_ozone_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the ozone mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_rain_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the rain mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_snow_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of the snow mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_tracers`: Process split cumulative tendency of tracers
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_tke`: Process-split cumulative change in turbulent kinetic energy per unit time
-    * `real(kind=kind_phys)`: units = J s-1
+    * `real`: units = J s-1
 * `process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols`: Process split cumulative tendency of mass number concentration of hygroscopic aerosols
-    * `real(kind=kind_phys)`: units = kg-1 s-1
+    * `real`: units = kg-1 s-1
 * `process_split_cumulative_tendency_of_water_vapor_mixing_ratio_wrt_moist_air`: Process-split cumulative tendency of specific humidity (water vapor mass mixing ratio with respect to moist air)
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `process_split_cumulative_tendency_of_x_wind`: Process split cumulative tendency of x wind
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `process_split_cumulative_tendency_of_y_wind`: Process split cumulative tendency of y wind
-    * `real(kind=kind_phys)`: units = m s-2
+    * `real`: units = m s-2
 * `vertical_interface_dimension_interstitial`: Vertical interface dimension interstitial
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 ## GFS_typedefs_GFS_tbd_type
 * `absolute_momentum_flux_due_to_nonorographic_gwd`: Absolute momentum flux due to non-orographic gravity wave drag
-    * `real(kind=kind_phys)`: units = various
-* `cumulative_lwe_thickness_of_convective_precipitation_amount_between_sw_radiation_calls`: Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = various
+* `cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls`: Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls
+    * `real`: units = m
 * `mass_number_concentration_of_aerosol_from_gocart_climatology`: Mass number concentration of aerosol from gocart climatology
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array`: Air temperature on previous timestep in xyz dimensioned restart array
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `air_temperature_two_timesteps_back`: Air temperature two timesteps back
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `atmosphere_boundary_layer_thickness`: Atmosphere boundary layer thickness
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `atmosphere_heat_diffusivity_from_shoc`: Atmospheric heat diffusivity from Simplified Higher-Order Closure stochastic physics scheme
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `atmosphere_updraft_convective_mass_flux_at_cloud_base_by_cloud_type`: Atmosphere updraft convective mass flux at cloud base by cloud type
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `cloud_fraction_for_mg`: Cloud fraction for mg
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `counter_for_grell_freitas_convection`: Counter for grell freitas convection
-    * `integer(kind=)`: units = count
+    * `integer`: units = count
 * `convective_cloud_area_fraction`: Convective cloud area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `convective_cloud_condensate_mixing_ratio_wrt_moist_air`: Convective cloud condensate mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `effective_radius_of_stratiform_cloud_graupel_particle`: Effective radius of stratiform cloud graupel particle
-    * `real(kind=kind_phys)`: units = um
+    * `real`: units = um
 * `effective_radius_of_stratiform_cloud_ice_particle`: Effective radius of stratiform cloud ice particle
-    * `real(kind=kind_phys)`: units = um
+    * `real`: units = um
 * `effective_radius_of_stratiform_cloud_liquid_water_particle`: Effective radius of stratiform cloud liquid water particle
-    * `real(kind=kind_phys)`: units = um
+    * `real`: units = um
 * `effective_radius_of_stratiform_cloud_rain_particle`: Effective radius of stratiform cloud rain particle
-    * `real(kind=kind_phys)`: units = um
+    * `real`: units = um
 * `effective_radius_of_stratiform_cloud_snow_particle`: Effective radius of stratiform cloud snow particle
-    * `real(kind=kind_phys)`: units = um
+    * `real`: units = um
 * `stratospheric_water_vapor_forcing`: Stratospheric water vapor forcing
-    * `real(kind=kind_phys)`: units = various
+    * `real`: units = various
 * `heat_exchange_coefficient_for_myj_schemes`: Heat exchange coefficient for Mellor-Yamada-Janjic physics schemes
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `ice_nucleation_number_from_climatology`: Ice nucleation number from climatology
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `upward_virtual_potential_temperature_flux`: Upward virtual potential temperature flux
-    * `real(kind=kind_phys)`: units = K m s-1
+    * `real`: units = K m s-1
 * `upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_surface_layer_scheme`: Upward flux of specific humidity (water vapor mass mixing ratio with respect to moist air) at surface for MYJ surface layer scheme
-    * `real(kind=kind_phys)`: units = m s-1 kg kg-1
+    * `real`: units = m s-1 kg kg-1
 * `cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative maximum vertical index at cloud base between shortwave radiation calls
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `map_of_block_column_number_to_global_i_index`: Map of block column number to global i index
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `map_of_block_column_number_to_global_j_index`: Map of block column number to global j index
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `turbulent_mixing_length`: Turbulent mixing length
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep`: Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_nonphysics`: Tendency of specific humidity (water vapor mass mixing ratio with respect to moist air) due to non-physics processes
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `momentum_exchange_coefficient_for_myj_schemes`: Momentum exchange coefficient for Mellor-Yamada-Janjic physics schemes
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `ozone_forcing`: Ozone forcing
-    * `real(kind=kind_phys)`: units = various
+    * `real`: units = various
 * `potential_temperature_of_air_at_top_of_viscous_sublayer`: Potential temperature of air at top of viscous sublayer
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `variance_of_water_vapor_mixing_ratio_wrt_moist_air`: Variance of specific humidity (water vapor mass mixing ratio with respect to moist air)
-    * `real(kind=kind_phys)`: units = kg2 kg-2
+    * `real`: units = kg2 kg-2
 * `random_number`: Random number
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `random_number_seed_for_mcica_longwave`: Random number seed for Monte-Carlo Independent Column Approximation longwave scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `random_number_seed_for_mcica_shortwave`: Random number seed for Monte-Carlo Independent Column Approximation shortwave scheme
-    * `integer(kind=)`: units = 1
+    * `integer`: units = 1
 * `cumulative_min_vertical_index_at_cloud_base_between_sw_radiation_calls`: Cumulative min vertical index at cloud base between sw radiation calls
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `stability_function_for_heat`: Stability function for heat
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `subgrid_scale_cloud_area_fraction_in_atmosphere_layer`: Subgrid scale cloud area fraction in atmosphere layer
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `subgrid_scale_cloud_ice_mixing_ratio_wrt_moist_air`: Subgrid-scale cloud ice mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `subgrid_scale_cloud_liquid_water_mixing_ratio_wrt_moist_air`: Subgrid-scale cloud liquid water mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `subgrid_scale_cloud_fraction_from_shoc`: Subgrid-scale cloud fraction from Simplified Higher-Order Closure stochastic physics scheme
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `air_pressure_at_surface_on_previous_timestep`: Air pressure at surface on previous timestep
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_at_surface_two_timesteps_back`: Air pressure at surface two timesteps back
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `control_for_surface_layer_evaporation`: Control for surface layer evaporation
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_schemes`: Surface specific humidity (water vapor mass mixing ratio with respect to moist air) for Mellor-Yamada-Janjic physics schemes
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convection`: Enhancement to wind speed at surface adjacent layer due to convection
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `covariance_of_air_temperature_and_water_vapor_mixing_ratio_wrt_moist_air`: Covariance of air temperature and specific humidity (water vapor mass mixing ratio with respect to moist air)
-    * `real(kind=kind_phys)`: units = K kg kg-1
+    * `real`: units = K kg kg-1
 * `variance_of_air_temperature`: Variance of air temperature
-    * `real(kind=kind_phys)`: units = K2
+    * `real`: units = K2
 * `tendency_of_air_temperature_due_to_nonphysics`: Tendency of air temperature due to nonphysics
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_air_temperature_to_withhold_from_sppt`: Change of air temperature to withhold from stochastically perturbed physics tendencies per unit time
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_activated_cloud_condensation_nuclei_from_climatology`: Change of activated cloud condensation nuclei from climatology per unit time
-    * `real(kind=kind_phys)`: units = kg-1 s-1
-* `lwe_thickness_of_rain_amount_on_dynamics_timestep_for_coupling`: Liquid water equivalent thickness of rain amount on dynamics timestep for coupling
-    * `real(kind=kind_phys)`: units = m
-* `lwe_thickness_of_snowfall_amount_on_dynamics_timestep_for_coupling`: Liquid water equivalent thickness of snowfall amount on dynamics timestep for coupling
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = kg-1 s-1
+* `lwe_thickness_of_rain_on_dynamics_timestep_for_coupling`: Liquid water equivalent thickness of rain amount on dynamics timestep for coupling
+    * `real`: units = m
+* `lwe_thickness_of_snowfall_on_dynamics_timestep_for_coupling`: Liquid water equivalent thickness of snowfall amount on dynamics timestep for coupling
+    * `real`: units = m
 * `nonadvected_tke_multiplied_by_2`: Non-advected turbulent kinetic energy multiplied by 2
-    * `real(kind=kind_phys)`: units = m2 s-2
+    * `real`: units = m2 s-2
 * `x_wind_at_top_of_viscous_sublayer`: X wind at top of viscous sublayer
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `y_wind_at_top_of_viscous_sublayer`: Y wind at top of viscous sublayer
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array`: Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in XYZ-dimensioned restart array
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back`: Specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `scaling_factor_for_momentum_at_top_of_viscous_sublayer`: Scaling factor for momentum at top of viscous sublayer
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `scaling_factor_for_potential_temperature_at_top_of_viscous_sublayer`: Scaling factor for potential temperature at top of viscous sublayer
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `scaling_factor_for_water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer`: Scaling factor for specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 ## GFS_typedefs_GFS_sfcprop_type
 * `wet_canopy_area_fraction`: Wet canopy area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `baseline_surface_longwave_emissivity`: Baseline surface longwave emissivity
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `baseline_roughness_length`: Baseline surface roughness length
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `air_temperature_in_canopy`: Air temperature in canopy
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `air_vapor_pressure_in_canopy`: Air vapor pressure in canopy
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `canopy_intercepted_ice_mass`: Canopy intercepted ice mass
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = mm
 * `canopy_intercepted_liquid_water`: Canopy intercepted liquid water
-    * `real(kind=kind_phys)`: units = mm
-* `canopy_water_amount`: Canopy water amount
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = mm
+* `canopy_water_mass_content`: Canopy water mass content
+    * `real`: units = kg m-2
 * `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_ice`: Cloud condensed water mass mixing ratio with respect to moist air at surface over ice
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land`: Cloud condensed water mass mixing ratio with respect to moist air at surface over land
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `coefficient_c_0`: Coefficient c 0
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `coefficient_c_d`: Coefficient c d
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `coefficient_w_0`: Coefficient w 0
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `coefficient_w_d`: Coefficient w d
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `convective_precipitation_rate_on_previous_timestep`: Convective precipitation rate on previous timestep
-    * `real(kind=kind_phys)`: units = mm s-1
+    * `real`: units = mm s-1
 * `deep_soil_temperature`: Deep soil temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `frozen_precipitation_density`: Frozen precipitation density
-    * `real(kind=kind_phys)`: units = kg m-3
+    * `real`: units = kg m-3
 * `heat_content_in_diurnal_thermocline`: Heat content in diurnal thermocline
-    * `real(kind=kind_phys)`: units = K m
+    * `real`: units = K m
 * `diurnal_thermocline_layer_thickness`: Diurnal thermocline layer thickness
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `x_current_in_diurnal_thermocline`: X current in diurnal thermocline
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `y_current_in_diurnal_thermocline`: Y current in diurnal thermocline
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `volumetric_equilibrium_soil_moisture`: Volumetric equilibrium soil moisture
-    * `real(kind=kind_phys)`: units = m3 m-3
+    * `real`: units = m3 m-3
 * `explicit_precipitation_rate_on_previous_timestep`: Explicit precipitation rate on previous timestep
-    * `real(kind=kind_phys)`: units = mm s-1
+    * `real`: units = mm s-1
 * `fast_soil_pool_mass_content_of_carbon`: Fast soil pool mass content of carbon
-    * `real(kind=kind_phys)`: units = g m-2
+    * `real`: units = g m-2
 * `fine_root_mass_content`: Fine root mass content
-    * `real(kind=kind_phys)`: units = g m-2
+    * `real`: units = g m-2
 * `control_for_frozen_soil_physics`: Control for frozen soil physics
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `precipitation_type`: Precipitation type
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `strong_cosz_area_fraction`: Strong cosz area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `weak_cosz_area_fraction`: Weak cosz area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `free_convection_layer_thickness_in_sea_water`: Free convection layer thickness in sea water
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `consecutive_calls_for_grell_freitas_convection`: Consecutive calls for grell freitas convection
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `graupel_precipitation_rate_on_previous_timestep`: Graupel precipitation rate on previous timestep
-    * `real(kind=kind_phys)`: units = mm s-1
+    * `real`: units = mm s-1
 * `ground_temperature`: Ground temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `ice_precipitation_rate_on_previous_timestep`: Ice precipitation rate on previous timestep
-    * `real(kind=kind_phys)`: units = mm s-1
+    * `real`: units = mm s-1
 * `control_for_diurnal_thermocline_calculation`: Control for diurnal thermocline calculation
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `temperature_in_ice_layer`: Temperature in ice layer
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Upward flux of water vapor mixing ratio wrt moist air at surface
-    * `real(kind=kind_phys)`: units = kg kg-1 m s-1
+    * `real`: units = kg kg-1 m s-1
 * `upward_temperature_flux_at_surface`: Upward temperature flux at surface
-    * `real(kind=kind_phys)`: units = K m s-1
+    * `real`: units = K m s-1
 * `lake_area_fraction`: Lake area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `lake_depth`: Lake depth
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `water_storage_in_lake`: Water storage in lake
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = mm
 * `land_area_fraction`: Land area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `depth_from_snow_surface_at_bottom_interface`: Depth from snow surface at bottom interface
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `leaf_area_index`: Leaf area index
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `leaf_mass_content`: Leaf mass content
-    * `real(kind=kind_phys)`: units = g m-2
-* `lwe_thickness_of_convective_precipitation_amount_on_previous_timestep`: Liquid water equivalent thickness of convective precipitation amount on previous timestep
-    * `real(kind=kind_phys)`: units = m
-* `lwe_thickness_of_explicit_precipitation_amount_on_previous_timestep`: Liquid water equivalent thickness of explicit precipitation amount on previous timestep
-    * `real(kind=kind_phys)`: units = m
-* `lwe_thickness_of_graupel_amount_on_previous_timestep`: Liquid water equivalent thickness of graupel amount on previous timestep
-    * `real(kind=kind_phys)`: units = m
-* `lwe_thickness_of_ice_precipitation_amount_on_previous_timestep`: Liquid water equivalent thickness of ice precipitation amount on previous timestep
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = g m-2
+* `lwe_thickness_of_convective_precipitation_on_previous_timestep`: Liquid water equivalent thickness of convective precipitation amount on previous timestep
+    * `real`: units = m
+* `lwe_thickness_of_explicit_precipitation_on_previous_timestep`: Liquid water equivalent thickness of explicit precipitation amount on previous timestep
+    * `real`: units = m
+* `lwe_thickness_of_graupel_on_previous_timestep`: Liquid water equivalent thickness of graupel amount on previous timestep
+    * `real`: units = m
+* `lwe_thickness_of_ice_precipitation_on_previous_timestep`: Liquid water equivalent thickness of ice precipitation amount on previous timestep
+    * `real`: units = m
 * `snow_mass_on_previous_timestep`: Snow mass on previous timestep
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `max_vegetation_area_fraction`: Maximum vegetation area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `nir_albedo_strong_cosz`: albedo for near-infrared radiation with strong dependence on cosine of the zenith angle
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `nir_albedo_weak_cosz`: Nir albedo weak cosz
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `vis_albedo_strong_cosz`: Vis albedo strong cosz
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `vis_albedo_weak_cosz`: Vis albedo weak cosz
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `min_vegetation_area_fraction`: Min vegetation area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `monin_obukhov_similarity_function_for_heat`: Monin obukhov similarity function for heat
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `monin_obukhov_similarity_function_for_momentum`: Monin obukhov similarity function for momentum
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `dimensionless_age_of_surface_snow`: Dimensionless age of surface snow
-    * `real(kind=kind_phys)`: units = 1
-* `nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep`: Non-negative liquid water equivalent thickness of precipitation amount on dynamics timestep
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = 1
+* `nonnegative_lwe_thickness_of_precipitation_on_dynamics_timestep`: Non-negative liquid water equivalent thickness of precipitation amount on dynamics timestep
+    * `real`: units = m
 * `normalized_soil_wetness_for_lsm`: Normalized soil wetness for land surface model
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `number_of_snow_layers`: Number of snow layers
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `ocean_mixed_layer_thickness`: Ocean mixed layer thickness
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `height_above_mean_sea_level`: Height above mean sea level
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `height_above_mean_sea_level_at_surface`: Height above mean sea level at local surface
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `unfiltered_height_above_mean_sea_level`: Unfiltered height above mean sea level
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `potential_temperature_of_air_at_2m`: Potential temperature of air at 2m
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `ratio_of_wind_at_surface_adjacent_layer_to_wind_at_10m`: Ratio of wind at surface adjacent layer to wind at 10m
-    * `real(kind=kind_phys)`: units = ratio
+    * `real`: units = ratio
 * `reciprocal_of_obukhov_length`: Reciprocal of obukhov length
-    * `real(kind=kind_phys)`: units = m-1
+    * `real`: units = m-1
 * `sea_area_fraction`: Sea area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `sea_ice_area_fraction_of_sea_area_fraction`: Sea ice area fraction of sea area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `sea_ice_temperature`: Sea ice temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `sea_ice_thickness`: Sea ice thickness
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `area_type`: Area type
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `reference_sea_surface_temperature`: Reference sea surface temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `sea_surface_temperature`: Sea surface temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `sea_water_salinity_in_diurnal_thermocline`: Sea water salinity in diurnal thermocline
-    * `real(kind=kind_phys)`: units = ppt m
+    * `real`: units = ppt m
 * `surface_sensible_heat_due_to_rainfall`: Surface sensible heat due to rainfall
-    * `real(kind=kind_phys)`: units = W
+    * `real`: units = W
 * `derivative_of_heat_content_in_diurnal_thermocline_wrt_surface_skin_temperature`: Derivative of heat content in diurnal thermocline wrt surface skin temperature
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `derivative_of_diurnal_thermocline_layer_thickness_wrt_surface_skin_temperature`: Derivative of diurnal thermocline layer thickness wrt surface skin temperature
-    * `real(kind=kind_phys)`: units = m K-1
+    * `real`: units = m K-1
 * `slow_soil_pool_mass_content_of_carbon`: Slow soil pool mass content of carbon
-    * `real(kind=kind_phys)`: units = g m-2
+    * `real`: units = g m-2
 * `albedo_on_previous_timestep_assuming_deep_snow`: Albedo on previous timestep assuming deep snow
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `lwe_thickness_of_ice_in_surface_snow`: Liquid water equivalent thickness of ice in surface snow
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = mm
 * `lwe_thickness_of_liquid_water_in_surface_snow`: Liquid water equivalent thickness of liquid water in surface snow
-    * `real(kind=kind_phys)`: units = mm
-* `lwe_thickness_of_snowfall_amount_on_previous_timestep`: Liquid water equivalent thickness of snowfall amount on previous timestep
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = mm
+* `lwe_thickness_of_snowfall_on_previous_timestep`: Liquid water equivalent thickness of snowfall amount on previous timestep
+    * `real`: units = mm
 * `lwe_snowfall_rate`: Liquid water equivalent snowfall rate
-    * `real(kind=kind_phys)`: units = mm s-1
+    * `real`: units = mm s-1
 * `snowfall_rate_on_previous_timestep`: Snowfall rate on previous timestep
-    * `real(kind=kind_phys)`: units = mm s-1
+    * `real`: units = mm s-1
 * `temperature_in_surface_snow`: Temperature in surface snow
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `temperature_in_surface_snow_at_surface_adjacent_layer_over_ice`: Temperature in surface snow at surface adjacent layer over ice
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `temperature_in_surface_snow_at_surface_adjacent_layer_over_land`: Temperature in surface snow at surface adjacent layer over land
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `soil_temperature`: Soil temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `soil_temperature_for_lsm`: Soil temperature for land surface model
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `volumetric_soil_moisture_between_soil_bottom_and_water_table`: Volumetric soil moisture between soil bottom and water table
-    * `real(kind=kind_phys)`: units = m3 m-3
+    * `real`: units = m3 m-3
 * `water_vapor_mixing_ratio_wrt_moist_air_at_2m`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at two meters above surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m`: mixing ratio of the mass of water vapor to the mass of moist air and hydrometeors, at two meters above surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specified upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface
-    * `real(kind=kind_phys)`: units = kg kg-1 m s-1
+    * `real`: units = kg kg-1 m s-1
 * `specified_upward_temperature_flux_at_surface`: Specified upward temperature flux at surface
-    * `real(kind=kind_phys)`: units = K m s-1
+    * `real`: units = K m s-1
 * `standard_deviation_of_subgrid_orography`: Standard deviation of subgrid orography
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `statistical_measures_of_subgrid_orography_collection_array`: Statistical measures of subgrid orography collection array
-    * `real(kind=kind_phys)`: units = various
+    * `real`: units = various
 * `stem_area_index`: Stem area index
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `stem_mass_content`: Stem mass content
-    * `real(kind=kind_phys)`: units = g m-2
+    * `real`: units = g m-2
 * `molecular_sublayer_temperature_correction_in_sea_water`: Molecular sublayer temperature correction in sea water
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `molecular_sublayer_thickness_in_sea_water`: Molecular sublayer thickness in sea water
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `diffuse_nir_albedo_of_ice`: ice surface albedo for diffuse near-infrared radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `diffuse_nir_albedo_of_land`: land surface albedo for diffuse near-infrared radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `diffuse_vis_albedo_of_ice`: ice surface albedo for diffuse visible radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `diffuse_vis_albedo_of_land`: land surface albedo for diffuse visible radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `direct_nir_albedo_of_ice`: ice surface albedo for direct near-infrared radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `direct_nir_albedo_of_land`: land surface albedo for direct near-infrared radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `direct_vis_albedo_of_ice`: ice surface albedo for direct visible radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `direct_vis_albedo_of_land`: land surface albedo for direct visible radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `diffuse_shortwave_albedo_of_ice`: ice surface albedo for diffuse shortwave radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `diffuse_shortwave_albedo_of_land`: land surface albedo for diffuse shortwave radiation
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `surface_drag_coefficient_for_heat_and_moisture_for_noahmp`: Surface drag coefficient for heat and moisture for Noah land surface model with multiparameterization options
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `surface_drag_coefficient_for_momentum_for_noahmp`: Surface drag coefficient for momentum for Noah land surface model with multiparameterization options
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `surface_exchange_coefficient_for_heat`: Surface exchange coefficient for heat
-    * `real(kind=kind_phys)`: units = W m-2 K-1
+    * `real`: units = W m-2 K-1
 * `surface_exchange_coefficient_for_heat_at_2m`: Surface exchange coefficient for heat at 2m
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `surface_exchange_coefficient_for_moisture`: Surface exchange coefficient for moisture
-    * `real(kind=kind_phys)`: units = kg m-2 s-1
+    * `real`: units = kg m-2 s-1
 * `surface_exchange_coefficient_for_moisture_at_2m`: Surface exchange coefficient for moisture at 2m
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `surface_friction_velocity`: Surface friction velocity
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `surface_friction_velocity_for_momentum`: Surface friction velocity for momentum
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `upward_latent_heat_flux_at_surface`: Upward latent heat flux at surface
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `surface_longwave_emissivity_over_ice`: Surface longwave emissivity over ice
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `surface_longwave_emissivity_over_land`: Surface longwave emissivity over land
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `roughness_length`: surface roughness length
-    * `real(kind=kind_phys)`: units = cm
+    * `real`: units = cm
 * `roughness_length_from_wave_model`: surface roughness length from wave model
-    * `real(kind=kind_phys)`: units = cm
+    * `real`: units = cm
 * `roughness_length_over_ice`: surface roughness length over ice
-    * `real(kind=kind_phys)`: units = cm
+    * `real`: units = cm
 * `roughness_length_over_land`: surface roughness length over land
-    * `real(kind=kind_phys)`: units = cm
+    * `real`: units = cm
 * `roughness_length_over_water`: surface roughness length over water
-    * `real(kind=kind_phys)`: units = cm
+    * `real`: units = cm
 * `skin_temperature_at_surface`: Skin temperature at surface
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `skin_temperature_at_surface_over_ice`: Skin temperature at surface over (or where) ice
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `skin_temperature_at_surface_over_land`: Skin temperature at surface over (or where) land
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `skin_temperature_at_surface_over_ocean`: Skin temperature at surface over (or where) ocean
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `skin_temperature_at_surface_over_snow`: Skin temperature at surface over (or where) snow
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `snow_area_fraction_at_surface_over_ice`: Snow area fraction at surface over ice
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `snow_area_fraction_at_surface_over_land`: Snow area fraction at surface over land
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `albedo_of_land_assuming_no_snow_cover`: surface snow-free albedo over land
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `lwe_surface_snow`: Liquid water equivalent surface snow
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = mm
 * `water_vapor_mixing_ratio_wrt_moist_air_at_surface`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `ratio_of_height_to_monin_obukhov_length`: Ratio of height to monin obukhov length
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `air_temperature_at_2m`: Air temperature at 2m
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `surface_temperature_scale`: Surface temperature scale
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `time_since_last_snowfall`: Time since last snowfall
-    * `real(kind=kind_phys)`: units = s
-* `surface_snow_amount_over_ice`: Surface snow amount over ice
-    * `real(kind=kind_phys)`: units = kg m-2
-* `surface_snow_amount_over_land`: Surface snow amount over land
-    * `real(kind=kind_phys)`: units = kg m-2
+    * `real`: units = s
+* `surface_snow_mass_content_over_ice`: Surface snow mass content over ice
+    * `real`: units = kg m-2
+* `surface_snow_mass_content_over_land`: Surface snow mass content over land
+    * `real`: units = kg m-2
 * `upper_bound_of_max_albedo_assuming_deep_snow`: Upper bound of maximum albedo assuming deep snow
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `vegetation_area_fraction`: Vegetation area fraction
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `canopy_temperature`: Canopy temperature
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `volume_fraction_of_frozen_soil_moisture_for_lsm`: Volume fraction of frozen soil moisture for land surface model
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `volume_fraction_of_condensed_water_in_soil`: Volume fraction of condensed water in soil
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `volume_fraction_of_soil_moisture_for_lsm`: Volume fraction of soil moisture for land surface model
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `volume_fraction_of_unfrozen_water_in_soil`: Volume fraction of unfrozen water in soil
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `volume_fraction_of_unfrozen_soil_moisture_for_lsm`: Volume fraction of unfrozen soil moisture for land surface model
-    * `real(kind=kind_phys)`: units = fraction
-* `lwe_thickness_of_surface_snow_amount`: Liquid water equivalent thickness of surface snow amount
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = fraction
+* `lwe_thickness_of_surface_snow`: Liquid water equivalent thickness of surface snow amount
+    * `real`: units = mm
 * `water_storage_in_aquifer`: Water storage in aquifer
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = mm
 * `water_storage_in_aquifer_and_saturated_soil`: Water storage in aquifer and saturated soil
-    * `real(kind=kind_phys)`: units = mm
+    * `real`: units = mm
 * `water_table_depth`: Water table depth
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `water_table_recharge_assuming_deep`: Water table recharge assuming deep
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `water_table_recharge_assuming_shallow`: Water table recharge assuming shallow
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_ice`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over ice
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_land`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over land
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `wood_mass_content`: Wood mass content
-    * `real(kind=kind_phys)`: units = g m-2
+    * `real`: units = g m-2
 ## GFS_typedefs_GFS_coupling_type
 * `cellular_automata_global_pattern_from_coupled_process`: Cellular automata global pattern from coupled process
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `convective_cloud_condensate_after_rainout`: Convective cloud condensate after rainout
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling longwave flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative downwelling shortwave flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: cumulative net downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_net_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling longwave flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_net_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative net downwelling shortwave flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_upward_latent_heat_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative upward latent heat flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_upward_sensible_heat_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative upward sensible heat flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = J m-2
+    * `real`: units = J m-2
 * `cumulative_x_momentum_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative x momentum flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = Pa s
+    * `real`: units = Pa s
 * `cumulative_y_momentum_flux_at_surface_for_coupling_multiplied_by_timestep`: Cumulative y momentum flux at surface for coupling multiplied by timestep
-    * `real(kind=kind_phys)`: units = Pa s
+    * `real`: units = Pa s
 * `cellular_automata_area_fraction_for_deep_convection_from_coupled_process`: Cellular automata area fraction for deep convection from coupled process
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `atmosphere_heat_diffusivity_for_chemistry_coupling`: Atmosphere heat diffusivity for chemistry coupling
-    * `real(kind=kind_phys)`: units = m2 s-1
+    * `real`: units = m2 s-1
 * `water_vapor_mixing_ratio_wrt_moist_air_at_2m_for_coupling`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at 2 meters above surface used for coupling
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `air_pressure_at_surface_for_coupling`: Air pressure at surface for coupling
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: downwelling diffuse near-infrared shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: downwelling direct near-infrared shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_longwave_flux_at_surface_for_coupling`: Downwelling longwave flux at surface for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_shortwave_flux_at_surface_for_coupling`: Downwelling shortwave flux at surface for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling`: net downwelling diffuse near-infrared shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling`: net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling`: net downwelling direct near-infrared shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling`: net_downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `net_downwelling_longwave_flux_at_surface_for_coupling`: Net downwelling longwave flux at surface for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `net_downwelling_shortwave_flux_at_surface_for_coupling`: Net downwelling shortwave flux at surface for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `surface_skin_temperature_for_coupling`: Surface skin temperature for coupling
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `upward_latent_heat_flux_at_surface_for_coupling`: Upward latent heat flux at surface for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upward_sensible_heat_flux_at_surface_for_chemistry_coupling`: Upward sensible heat flux at surface for chemistry coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upward_sensible_heat_flux_at_surface_for_coupling`: Upward sensible heat flux at surface for coupling
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `x_momentum_flux_at_surface_for_coupling`: X momentum flux at surface for coupling
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `y_momentum_flux_at_surface_for_coupling`: Y momentum flux at surface for coupling
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `temperature_at_2m_for_coupling`: Temperature at 2m for coupling
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_moist_convection_for_coupling`: Tendency of water vapor mixing ratio wrt moist air due to moist convection for coupling
-    * `real(kind=kind_phys)`: units = kg kg-1 s-1
+    * `real`: units = kg kg-1 s-1
 * `x_wind_at_10m_for_coupling`: X wind at 10m for coupling
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `y_wind_at_10m_for_coupling`: Y wind at 10m for coupling
-    * `real(kind=kind_phys)`: units = m s-1
-* `cumulative_lwe_thickness_of_convective_precipitation_amount_for_coupling`: Cumulative liquid water equivalent thickness of convective precipitation amount for coupling
-    * `real(kind=kind_phys)`: units = m
-* `cumulative_lwe_thickness_of_precipitation_amount_for_coupling`: Cumulative liquid water equivalent thickness of precipitation amount for coupling
-    * `real(kind=kind_phys)`: units = m
-* `cumulative_lwe_thickness_of_snow_amount_for_coupling`: Cumulative liquid water equivalent thickness of snow amount for coupling
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m s-1
+* `cumulative_lwe_thickness_of_convective_precipitation_for_coupling`: Cumulative liquid water equivalent thickness of convective precipitation amount for coupling
+    * `real`: units = m
+* `cumulative_lwe_thickness_of_precipitation_for_coupling`: Cumulative liquid water equivalent thickness of precipitation amount for coupling
+    * `real`: units = m
+* `cumulative_lwe_thickness_of_snow_for_coupling`: Cumulative liquid water equivalent thickness of snow amount for coupling
+    * `real`: units = m
 * `physics_field_for_coupling`: Physics field for coupling
-    * `real(kind=kind_phys)`: units = m2 s-2
+    * `real`: units = m2 s-2
 * `rrtmgp_jacobian_of_upward_lw_flux`: Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) jacobian of upward longwave flux
-    * `real(kind=kind_phys)`: units = W m-2 K-1
+    * `real`: units = W m-2 K-1
 * `rrtmgp_lw_downward_allsky_flux_profile`: Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave downward all-sky flux profile
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `rrtmgp_lw_upward_allsky_flux_profile`: Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave upward all-sky flux profile
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `area_type_from_coupled_process`: Area type from coupled process
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: downwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: downwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: downwelling direct near-infrared shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: downwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_longwave_flux_at_surface_on_radiation_timestep`: Downwelling longwave flux at surface on radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `downwelling_shortwave_flux_at_surface_on_radiation_timestep`: Downwelling shortwave flux at surface on radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `net_downwelling_shortwave_flux_at_surface_on_radiation_timestep`: Net downwelling shortwave flux at surface on radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `diffuse_nir_albedo_for_coupling`: surface albedo for diffuse near-infrared radiation for coupling
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `direct_nir_albedo_for_coupling`: surface albedo for direct near-infrared radiation for coupling
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `lwe_surface_snow_from_coupled_process`: Liquid water equivalent surface snow from coupled process
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `upward_latent_heat_flux_at_surface_from_coupled_process`: Upward latent heat flux at surface from coupled process
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upward_sensible_heat_flux_at_surface_from_coupled_process`: Upward sensible heat flux at surface from coupled process
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep`: upwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: upwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep`: upwelling direct near-infrared shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep`: upwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upwelling_longwave_flux_at_surface_from_coupled_process`: Upwelling longwave flux at surface from coupled process
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `upwelling_longwave_flux_at_surface_on_radiation_timestep`: Upwelling longwave flux at surface on radiation timestep
-    * `real(kind=kind_phys)`: units = W m-2
+    * `real`: units = W m-2
 * `diffuse_vis_albedo_for_coupling`: surface albedo for diffuse visible radiation for coupling
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `direct_vis_albedo_for_coupling`: surface albedo for direct visible radiation for coupling
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `x_momentum_flux_at_surface_from_coupled_process`: X momentum flux at surface from coupled process
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `y_momentum_flux_at_surface_from_coupled_process`: Y momentum flux at surface from coupled process
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer`: Tendency of nonhygroscopic ice nucleating aerosols at surface adjacent layer
-    * `real(kind=kind_phys)`: units = kg-1 s-1
+    * `real`: units = kg-1 s-1
 * `tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer`: Tendency of hygroscopic aerosols at surface adjacent layer
-    * `real(kind=kind_phys)`: units = kg-1 s-1
+    * `real`: units = kg-1 s-1
 * `updated_tendency_of_air_temperature_due_to_longwave_heating_on_physics_timestep`: Updated tendency of air temperature due to longwave heating on physics timestep
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `cellular_automata_vertical_scaling_factor`: Cellular automata vertical scaling factor
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `shum_scaling_factors_from_coupled_process`: Stochastic Humidity stochastic physics option scaling factors from coupled process
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `skeb_x_wind_scaling_factors_from_coupled_process`: Stochastic Kinetic Energy Backscatter x-wind scaling factors from coupled process
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `skeb_y_wind_scaling_factors_from_coupled_process`: Stochastic Kinetic Energy Backscatter y-wind scaling factors from coupled process
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `sppt_scaling_factors_from_coupled_process`: Stochastically perturbed physics tendencies scaling factors from coupled process
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `surface_stochastic_scaling_factors_from_coupled_process`: Surface stochastic scaling factors from coupled process
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 ## GFS_typedefs_GFS_statein_type
 * `air_pressure_at_lowest_model_interface`: Air pressure at lowest model interface
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_pressure_at_surface_adjacent_layer`: Air pressure at surface adjacent layer
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `air_temperature_at_surface_adjacent_layer`: Air temperature at surface adjacent layer
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer`: Cloud liquid water mass mixing ratio with respect to moist air at surface-adjacent layer
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air`: Mass number concentration of cloud liquid water particles in air
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `exner_function_wrt_surface_pressure`: Exner function with respect to surface pressure, (p/ps)^(Rd/cp)
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `exner_function_at_surface_adjacent_layer`: exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at the surface-adjacent layer
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `exner_function_at_interfaces`: exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at vertical layer interfaces
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `dissipation_estimate_of_air_temperature_at_model_layers`: Dissipation estimate of air temperature at model layers
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `geopotential`: Geopotential
-    * `real(kind=kind_phys)`: units = m2 s-2
+    * `real`: units = m2 s-2
 * `geopotential_at_interfaces`: Geopotential at interfaces
-    * `real(kind=kind_phys)`: units = m2 s-2
+    * `real`: units = m2 s-2
 * `graupel_mixing_ratio_wrt_moist_air`: Graupel mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_graupel_in_air`: Mass number concentration of graupel in air
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols`: Mass number concentration of nonhygroscopic ice nucleating aerosols
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `mass_number_concentration_of_cloud_ice_water_crystals_in_air`: Mass number concentration of cloud ice water crystals in air
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `ozone_mixing_ratio_wrt_moist_air`: Ozone mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_rain_in_air`: Mass number concentration of rain in air
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `mass_number_concentration_of_snow_in_air`: Mass number concentration of snow in air
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `snow_mixing_ratio_wrt_moist_air`: Snow mass mixing ratio with respect to moist air
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `tracer_concentration`: Tracer concentration
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_hygroscopic_aerosols`: Mass number concentration of hygroscopic aerosols
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer`: Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface-adjacent layer
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `x_wind_at_surface_adjacent_layer`: X wind at surface adjacent layer
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `y_wind_at_surface_adjacent_layer`: Y wind at surface adjacent layer
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 ## GFS_typedefs_GFS_cldprop_type
 * `convective_cloud_area_fraction_between_sw_radiation_calls_from_cnvc90`: Convective cloud area fraction between shortwave radiation calls from GFS Convective Cloud Diagnostics
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `pressure_at_convective_cloud_base_between_sw_radiation_calls_from_cnvc90`: Pressure at convective cloud base between shortwave radiation calls from GFS Convective Cloud Diagnostics
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 * `pressure_at_convective_cloud_top_between_sw_radiation_calls_from_cnvc90`: Pressure at convective cloud top between shortwave radiation calls from GFS Convective Cloud Diagnostics
-    * `real(kind=kind_phys)`: units = Pa
+    * `real`: units = Pa
 ## GFS_typedefs_GFS_radtend_type
 * `cosine_of_solar_zenith_angle_for_daytime_points_on_radiation_timestep`: Cosine of solar zenith angle for daytime points on radiation timestep
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `cosine_of_solar_zenith_angle_on_radiation_timestep`: Cosine of solar zenith angle on radiation timestep
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `surface_lw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep`: Surface lw fluxes assuming total and clear sky on radiation timestep
-    * `sfcflw_type(kind=)`: units = W m-2
+    * `sfcflw_type`: units = W m-2
 * `diffuse_shortwave_albedo_on_radiation_timestep`: surface albedo for diffuse shortwave radiation on the timestep for radiation physics
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `surface_longwave_emissivity`: Surface longwave emissivity
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `air_temperature_at_surface_adjacent_layer_on_radiation_timestep`: Air temperature at surface adjacent layer on radiation timestep
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `surface_sw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep`: Surface sw fluxes assuming total and clear sky on radiation timestep
-    * `sfcfsw_type(kind=)`: units = W m-2
+    * `sfcfsw_type`: units = W m-2
 * `tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_timestep`: Tendency of air temperature due to longwave heating assuming clear sky on radiation timestep
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_integrated_dynamics_through_earths_atmosphere`: Tendency of air temperature due to integrated dynamics through earths atmosphere
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep`: Tendency of air temperature due to longwave heating on radiation timestep
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_timestep`: Tendency of air temperature due to shortwave heating assuming clear sky on radiation timestep
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 * `tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep`: Tendency of air temperature due to shortwave heating on radiation timestep
-    * `real(kind=kind_phys)`: units = K s-1
+    * `real`: units = K s-1
 ## GFS_typedefs_GFS_grid_type
 * `longitude_interpolation_scaling_factor_for_aerosol_forcing`: Longitude interpolation scaling factor for aerosol forcing
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `latitude_interpolation_scaling_factor_for_aerosol_forcing`: Latitude interpolation scaling factor for aerosol forcing
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `characteristic_grid_lengthscale`: Characteristic grid lengthscale
-    * `real(kind=kind_phys)`: units = m
+    * `real`: units = m
 * `longitude_interpolation_scaling_factor_for_cloud_nuclei_forcing`: Longitude interpolation scaling factor for cloud nuclei forcing
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `latitude_interpolation_scaling_factor_for_cloud_nuclei_forcing`: Latitude interpolation scaling factor for cloud nuclei forcing
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `cosine_of_latitude`: Cosine of latitude
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `latitude_interpolation_scaling_factor_complement_for_absolute_momentum_flux_due_to_nonorographic_gwd`: Latitude interpolation scaling factor complement for absolute momentum flux due to non-orographic gravity wave drag
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `latitude_interpolation_scaling_factor_for_absolute_momentum_flux_due_to_nonorographic_gwd`: Latitude interpolation scaling factor for absolute momentum flux due to non-orographic gravity wave drag
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `lower_longitude_index_of_aerosol_forcing_for_interpolation`: Lower longitude index of aerosol forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `lower_latitude_index_of_aerosol_forcing_for_interpolation`: Lower latitude index of aerosol forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `lower_longitude_index_of_cloud_nuclei_forcing_for_interpolation`: Lower longitude index of cloud nuclei forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `lower_latitude_index_of_cloud_nuclei_forcing_for_interpolation`: Lower latitude index of cloud nuclei forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `lower_latitude_index_of_absolute_momentum_flux_due_to_nonorographic_gwd_for_interpolation`: Lower latitude index of absolute momentum flux due to non-orographic gravity wave drag for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `lower_latitude_index_of_ozone_forcing_for_interpolation`: Lower latitude index of ozone forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `lower_latitude_index_of_stratospheric_water_vapor_forcing_for_interpolation`: Lower latitude index of stratospheric water vapor forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `latitude_interpolation_scaling_factor_for_ozone_forcing`: Latitude interpolation scaling factor for ozone forcing
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `sine_of_latitude`: Sine of latitude
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 * `upper_longitude_index_of_aerosol_forcing_for_interpolation`: Upper longitude index of aerosol forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `upper_latitude_index_of_aerosol_forcing_for_interpolation`: Upper latitude index of aerosol forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `upper_longitude_index_of_cloud_nuclei_forcing_for_interpolation`: Upper longitude index of cloud nuclei forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `upper_latitude_index_of_cloud_nuclei_forcing_for_interpolation`: Upper latitude index of cloud nuclei forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `upper_latitude_index_of_absolute_momentum_flux_due_to_nonorographic_gwd_for_interpolation`: Upper latitude index of absolute momentum flux due to non-orographic gravity wave drag for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `upper_latitude_index_of_ozone_forcing_for_interpolation`: Upper latitude index of ozone forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `upper_latitude_index_of_stratospheric_water_vapor_forcing_for_interpolation`: Upper latitude index of stratospheric water vapor forcing for interpolation
-    * `integer(kind=)`: units = index
+    * `integer`: units = index
 * `latitude_interpolation_scaling_factor_for_stratospheric_water_vapor_forcing`: Latitude interpolation scaling factor for stratospheric water vapor forcing
-    * `real(kind=kind_phys)`: units = 1
+    * `real`: units = 1
 ## GFS_typedefs_GFS_stateout_type
 * `air_temperature_of_new_state_at_surface_adjacent_layer`: Air temperature of new state at surface adjacent layer
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `air_temperature_of_new_state`: Air temperature of new state
-    * `real(kind=kind_phys)`: units = K
+    * `real`: units = K
 * `cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state`: Cloud liquid water mass mixing ratio with respect to moist air of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state`: Mass number concentration of cloud liquid water particles in air of new state
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `nonconvective_cloud_area_fraction_in_atmosphere_layer_of_new_state`: Nonconvective cloud area fraction in atmosphere layer of new state
-    * `real(kind=kind_phys)`: units = fraction
+    * `real`: units = fraction
 * `graupel_mixing_ratio_wrt_moist_air_of_new_state`: Graupel mass mixing ratio with respect to moist air of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_graupel_of_new_state`: Mass number concentration of graupel of new state
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_of_new_state`: Mass number concentration of nonhygroscopic ice nucleating aerosols of new state
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `mass_number_concentration_of_cloud_ice_water_crystals_in_air_of_new_state`: Mass number concentration of cloud ice water crystals in air of new state
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `cloud_ice_mixing_ratio_wrt_moist_air_of_new_state`: Cloud ice mass mixing ratio with respect to moist air of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_weighted_rime_factor_of_new_state`: Mass weighted rime factor of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `ozone_concentration_of_new_state`: Ozone concentration of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_rain_of_new_state`: Mass number concentration of rain of new state
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `rain_mixing_ratio_wrt_moist_air_of_new_state`: Rain mass mixing ratio with respect to moist air of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_snow_of_new_state`: Mass number concentration of snow of new state
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `snow_mixing_ratio_wrt_moist_air_of_new_state`: Snow mass mixing ratio with respect to moist air of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `tracer_concentration_of_new_state`: Tracer concentration of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `mass_number_concentration_of_hygroscopic_aerosols_of_new_state`: Mass number concentration of hygroscopic aerosols of new state
-    * `real(kind=kind_phys)`: units = kg-1
+    * `real`: units = kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_of_new_state_at_surface_adjacent_layer`: Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state at surface-adjacent layer
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `water_vapor_mixing_ratio_wrt_moist_air_of_new_state`: Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state
-    * `real(kind=kind_phys)`: units = kg kg-1
+    * `real`: units = kg kg-1
 * `x_wind_of_new_state_at_surface_adjacent_layer`: X wind of new state at surface adjacent layer
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `x_wind_of_new_state`: X wind of new state
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `y_wind_of_new_state_at_surface_adjacent_layer`: Y wind of new state at surface adjacent layer
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1
 * `y_wind_of_new_state`: Y wind of new state
-    * `real(kind=kind_phys)`: units = m s-1
+    * `real`: units = m s-1

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -39,7 +39,7 @@ ESM Standard Name Rules
    but have since evolved for better consistency and generality across a broader set of fields
    than was originally envisioned by the CF conventions. "``medium``" should be specified when
    the variable in question is a substance or other quantity contained within some other medium
-   (e.g. for ``mole_fraction_of_ozone_in_air``, the base name is "ozone", while the medium is "air"). 
+   (e.g. for ``mole_fraction_of_ozone_in_air``, the base name is "ozone", while the medium is "air").
    "Transformation" refers to descriptors such as "``tendency_of``", "``log10``", or other operations or processes describing some transformation or adjustment of a variable; a detailed list of possible transformations can be found `later in this document <#transformations>`_.
    Other parts of the construction provide information about a variable's horizontal surface
    (e.g. ``at_cloud_base``), component (i.e. direction of variable, e.g. ``downward``), process (e.g.
@@ -139,9 +139,9 @@ ESM Standard Name Rules
    narrowly-defined context or a variable without the scope-narrowing qualifiers
    already exists and cannot be reused.
 
-   **Discouraged:** surface_upward_specific_humidity_flux_for_mellor_yamada_janjic_surface_layer_scheme
+   **Discouraged:** upward_virtual_potential_temperature_flux_for_mellor_yamada_janjic_surface_layer_scheme
 
-   **Preferred:** surface_upward_specific_humidity_flux
+   **Preferred:** upward_virtual_potential_temperature_flux
 
 #. Spell out acronyms unless they are obvious to a vast majority of
    scientists/developers who may come across them. A list of currently-used
@@ -152,12 +152,14 @@ ESM Standard Name Rules
    use flag_for ``_X``. If it is any other data type, use control_for ``_X``. All flags
    should be Fortran logicals.
 
-#. Reserved names: The prefix ``ccpp_`` represents CCPP framework-provided variables.
+#  **Disallowed terms:** A few terms are disallowed as standard name components for various reasons; mostly due to
+   ambiguity.
+
+   - `specific_humidity` Disallowed due to ambiguity and different definitions between different fields. See above section describing `mixing_ratio` for more information.
+   - `amount` In most contexts this word is superfluous, and in all contexts it is non-descriptive. Consider a more specific term such as `mass_content`
+
+#. **Reserved names:** The prefix ``ccpp_`` is reserved for CCPP framework-provided variables.
    All other standard names should avoid the use of ``ccpp`` in their name.
-
-#. No punctuation should appear in standard names except for underscores (_).
-
-#. Standard names are case insensitive, i.e. example = EXAMPLE.
 
 .. _tech_specs:
 
@@ -695,14 +697,15 @@ Acronyms, Abbreviations, and Aliases
 Units
 =====
 
-#. For variables with an existing match in the `Climate and Forecast (CF) metadata
-   conventions <https://cfconventions.org/standard-names.html>`_, the units should
-   be identical to the canonical units listed there
+Entries in the Standard Names dictionary contain a "units" property that serves to indicate the
+typical/recommended units for a given variable. It is not mandatory to use the indicated units exactly,
+but any use of a given standard name variable should have units of the same dimensionality.
 
-#. For variables without an existing match in the CF conventions, the units should
-   follow the `International System of Units (SI/metric system) <https://www.nist.gov/pml/weights-and-measures/metric-si/si-units>`_
+When adding a new standard name, units should follow the `International System of Units (SI/metric system) <http://nist.gov/pml/owm/metric-si/si-units>`_.
+If the new standard name has an existing match in the `Climate and Forecast (CF) metadata
+conventions <https://cfconventions.org/standard-names.html>`_, the units should be identical to the canonical units listed there
 
-#. For dimensionless variables, the following units can be used:
+For dimensionless variables, the following units can be used:
 
 +------------------------+-----------------------------------------------------------------------------------------------+
 | **Unit**               |  **Use case**                                                                                 |

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -174,18 +174,17 @@ Technical specifications
    individual implementations of the standard names. This is not necessarily the same as the ``long_name`` entry as described
    in the `CCPP Technical Documentation <https://ccpp-techdoc.readthedocs.io/en/latest/CompliantPhysicsParams.html#ccpp-arg-table>`_,
    but it can be used to inform the contents of that field. The ``standard_name`` XML entry also contains a nested
-   ``type`` entry, indicating the data type that a ``standard_name`` should represent, and as attributes the
-   physical units of that variable quantity (see the `section on Units <#units>`_) and the FORTRAN "kind"
-   of the variable quantity. For example, the element
+   ``type`` entry, indicating the data type that a ``standard_name`` should represent, and as an attribute the
+   physical units of that variable quantity (see the `section on Units <#units>`_). For example, the element
    for the variable name ``exner_function`` may look similar to this:
 
     <standard_name name="exner_function"
                    description="exner function, (p/p0)^(Rd/cp), where p0 is 1000 hPa">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
 
    This XML element indicates that the variable ``exner_function`` represents the quantity described by the ``description``
-   attribute. It is a real variable of "kind_phys" kind, and units of "1", meaning it is non-dimensional and
+   attribute. It is a real variable with units of "1", meaning it is non-dimensional and
    does not correspond to a more descriptive non-dimensional type such as "fraction"; see the `section on Units <#units>`_
    for more details.
 

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -56,7 +56,7 @@
         <type units="kg">real</type>
       </standard_name>
       <standard_name name="mass_content"
-                     description="Integrated mass over a given area and vertical extent">
+                     description="Vertically-integrated mass over a given area and vertical extent">
         <type units="kg m-2">real</type>
       </standard_name>
       <standard_name name="mass_flux"

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -332,7 +332,7 @@
       </standard_name>
       <standard_name name="exner_function"
                      description="Exner function, (p/p0)^(Rd/cp), where p0 is some reference pressure (1000 hPa if not specified)">
-        <type kind="kind_phys" units="1">real</type>
+        <type units="1">real</type>
       </standard_name>
       <standard_name name="friction_velocity"
                      description="A measure of shear stress within a fluid layer with units of distance per time">
@@ -346,7 +346,7 @@
       </standard_name>
       <standard_name name="geopotential"
                      description="Gravitational potential energy of a unit mass relative to sea level">
-        <type kind="kind_phys" units="m2 s-2">real</type>
+        <type units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="geopotential_height"
                      description="Geopotential divided by the gravitational constant">
@@ -564,820 +564,820 @@
   <section name="constants"
            comment="Constant parameters that should be identical across a full modeling system">
     <standard_name name="avogadro_number">
-      <type kind="kind_phys" units="molecules mol-1">real</type>
+      <type units="molecules mol-1">real</type>
     </standard_name>
     <standard_name name="base_state_surface_pressure_for_hybrid_vertical_coordinate">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="boltzmann_constant">
-      <type kind="kind_phys" units="J K-1">real</type>
+      <type units="J K-1">real</type>
     </standard_name>
     <standard_name name="density_of_dry_air_at_stp"
               description="Density of dry air at standard temperature and pressure">
-      <type kind="kind_phys" units="kg m-3">real</type>
+      <type units="kg m-3">real</type>
     </standard_name>
     <standard_name name="fresh_liquid_water_density_at_0c"
                    description="Density of liquid water at 0 degrees Celsius">
-      <type kind="kind_phys" units="kg m-3">real</type>
+      <type units="kg m-3">real</type>
     </standard_name>
     <standard_name name="gas_constant_of_dry_air">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+      <type units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name name="latent_heat_of_vaporization_of_water_at_0c"
                    description="Latent heat of vaporization of water at 0 degrees Celsius">
-      <type kind="kind_phys" units="J kg-1">real</type>
+      <type units="J kg-1">real</type>
     </standard_name>
     <standard_name
         name="ratio_of_water_vapor_to_dry_air_gas_constants_minus_one"
         description="Ratio of gas constants of water vapor and dry air minus one; (Rwv / Rdair) - 1.0">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="seconds_in_calendar_day">
-      <type kind="kind_phys" units="s">integer</type>
+      <type units="s">integer</type>
     </standard_name>
     <standard_name name="specific_heat_of_liquid_water_at_20c"
               description="Specific heat of liquid water at 20 degrees Celsius">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+      <type units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name
         name="standard_gravitational_acceleration"
         description="scalar constant representing gravitational acceleration">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
   </section>
   <section name="coordinates">
     <standard_name name="latitude">
-      <type kind="kind_phys" units="degree_north">real</type>
+      <type units="degree_north">real</type>
     </standard_name>
     <standard_name name="longitude">
-      <type kind="kind_phys" units="degree_east">real</type>
+      <type units="degree_east">real</type>
     </standard_name>
     <standard_name name="cell_area">
-      <type kind="kind_phys" units="m2">real</type>
+      <type units="m2">real</type>
     </standard_name>
     <standard_name name="cell_scaling_factor">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
   </section>
   <section name="state_variables"
            comment="Note that appending '_on_previous_timestep' to standard_names in this section yields another valid standard_name">
     <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+      <type units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name name="physics_state_due_to_dynamics">
-      <type kind="kind_phys" units="none">physics_state</type>
+      <type units="none">physics_state</type>
     </standard_name>
     <standard_name name="timestep_for_physics">
-      <type kind="kind_phys" units="s">integer</type>
+      <type units="s">integer</type>
     </standard_name>
     <standard_name name="total_tendency_of_physics">
-      <type kind="kind_phys" units="none">physics_tend</type>
+      <type units="none">physics_tend</type>
     </standard_name>
     <standard_name name="air_pressure_at_top_of_atmosphere_model">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_sea_level">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_surface"
                    description="Air pressure at local surface">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="surface_pressure_of_dry_air">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="geopotential_at_surface">
-      <type kind="kind_phys" units="m2 s-2">real</type>
+      <type units="m2 s-2">real</type>
     </standard_name>
     <standard_name name="air_temperature">
-      <type kind="kind_phys" units="K">real</type>
+      <type units="K">real</type>
     </standard_name>
     <standard_name name="air_temperature_on_previous_timestep">
-      <type kind="kind_phys" units="K">real</type>
+      <type units="K">real</type>
     </standard_name>
     <standard_name name="x_wind"
                    description="Horizontal wind in a direction perpendicular to y_wind">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="y_wind"
                    description="Horizontal wind in a direction perpendicular to x_wind">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="eastward_wind"
                    description="Wind vector component, positive when directed eastward">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="northward_wind"
                    description="Wind vector component, positive when directed northward">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="eastward_wind_at_10m"
                    description="Wind vector component at 10 meters above surface, positive when directed eastward">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="northward_wind_at_10m"
                    description="Wind vector component at 10 meters above surface, positive when directed northward">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="eastward_wind_at_surface"
                    description="Wind vector component closest to surface, positive when directed eastward">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="northward_wind_at_surface"
                    description="Wind vector component closest to surface, positive when directed northward">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="wind_speed_at_surface"
                    description="Scalar wind speed closest to surface">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
     <standard_name name="wind_from_direction_at_surface"
                    description="Direction, from north, of wind speed closest to surface">
-      <type kind="kind_phys" units="degrees">real</type>
+      <type units="degrees">real</type>
     </standard_name>
     <standard_name name="dry_static_energy"
                    description="Dry static energy content of atmosphere layer">
-      <type kind="kind_phys" units="J kg-1">real</type>
+      <type units="J kg-1">real</type>
     </standard_name>
     <standard_name name="flag_for_lagrangian_vertical_coordinate"
                    description="Flag indicating if vertical coordinate is lagrangian">
-      <type kind="" units="flag">logical</type>
+      <type units="flag">logical</type>
     </standard_name>
     <standard_name name="lagrangian_tendency_of_air_pressure"
                    description="Vertical pressure velocity">
-      <type kind="kind_phys" units="Pa s-1">real</type>
+      <type units="Pa s-1">real</type>
     </standard_name>
     <standard_name name="density_of_dry_air"
                    description="Density of dry air">
-      <type kind="kind_phys" units="kg m-3">real</type>
+      <type units="kg m-3">real</type>
     </standard_name>
     <standard_name name="air_pressure"
                    description="Midpoint air pressure">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_of_dry_air"
                    description="Dry midpoint pressure">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_thickness">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_thickness_of_dry_air">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="reciprocal_of_air_pressure_thickness">
-      <type kind="kind_phys" units="Pa-1">real</type>
+      <type units="Pa-1">real</type>
     </standard_name>
     <standard_name name="reciprocal_of_air_pressure_thickness_of_dry_air">
-      <type kind="kind_phys" units="Pa-1">real</type>
+      <type units="Pa-1">real</type>
     </standard_name>
     <standard_name name="ln_air_pressure">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="ln_air_pressure_of_dry_air">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="reciprocal_of_exner_function_wrt_air_pressure_at_surface"
                    description="inverse exner function with respect to surface pressure; (ps/p)^(R/cp)">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="geopotential_height"
                    description="geopotential height with respect to sea level">
-      <type kind="kind_phys" units="m">real</type>
+      <type units="m">real</type>
     </standard_name>
     <standard_name name="geopotential_height_at_surface"
                    description="Geopotential height at local surface with respect to sea level">
-      <type kind="kind_phys" units="m">real</type>
+      <type units="m">real</type>
     </standard_name>
     <standard_name name="geopotential_height_wrt_surface"
                    description="geopotential height with respect to local surface">
-      <type kind="kind_phys" units="m">real</type>
+      <type units="m">real</type>
     </standard_name>
     <standard_name name="geopotential_height_wrt_surface_at_interfaces"
                    description="geopotential height with respect to local surface at interfaces">
-      <type kind="kind_phys" units="m">real</type>
+      <type units="m">real</type>
     </standard_name>
     <standard_name name="potentially_advected_quantities">
-      <type kind="kind_phys" units="various">real</type>
+      <type units="various">real</type>
     </standard_name>
     <standard_name name="air_pressure_at_interfaces">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="air_pressure_of_dry_air_at_interfaces">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="ln_air_pressure_at_interfaces">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="ln_air_pressure_of_dry_air_at_interfaces">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="air_pressure_extended_up_by_1">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="largest_model_top_pressure_that_allows_molecular_diffusion">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="do_molecular_diffusion">
-      <type kind="kind_phys" units="flag">logical</type>
+      <type units="flag">logical</type>
     </standard_name>
     <standard_name name="is_initialized_physics_grid"
               description="Flag to indicate if physics grid is initialized">
-      <type kind="kind_phys" units="flag">logical</type>
+      <type units="flag">logical</type>
     </standard_name>
     <standard_name name="control_for_negative_constituent_warning"
               description="Logging setting for negative constituent mass fixer">
-      <type kind="len=*" units="1">character</type>
+      <type units="1">character</type>
     </standard_name>
     <standard_name name="geopotential_height_at_interfaces">
-      <type kind="kind_phys" units="m">real</type>
+      <type units="m">real</type>
     </standard_name>
     <standard_name name="vertically_integrated_total_energy_of_initial_state">
-      <type kind="kind_phys" units="J m-2">real</type>
+      <type units="J m-2">real</type>
     </standard_name>
     <standard_name name="vertically_integrated_total_energy_of_current_state">
-      <type kind="kind_phys" units="J m-2">real</type>
+      <type units="J m-2">real</type>
     </standard_name>
     <standard_name name="vertically_integrated_total_water_of_initial_state">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="vertically_integrated_total_water_of_current_state">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_dry_air_enthalpy_at_constant_pressure"
                    description="Change of dry air enthalpy per unit time at constant pressure; d/dt(Cp*T)">
-      <type kind="kind_phys" units="J kg-1 s-1">real</type>
+      <type units="J kg-1 s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature"
                    description="Change in temperature per unit time">
-      <type kind="kind_phys" units="K s-1">real</type>
+      <type units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_air_temperature_due_to_model_physics"
                    description="Change in air temperature due to model physics per unit time">
-      <type kind="kind_phys" units="K s-1">real</type>
+      <type units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_potential_temperature_of_air"
                    description="Change in potential temperature per unit time">
-      <type kind="kind_phys" units="K s-1">real</type>
+      <type units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_potential_temperature_of_air_due_to_model_physics"
                    description="Change of potential temperature of air due to model physics per unit time">
-      <type kind="kind_phys" units="K s-1">real</type>
+      <type units="K s-1">real</type>
     </standard_name>
     <standard_name name="tendency_of_x_wind"
                    description="Change in x wind per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_x_wind_due_to_model_physics"
                    description="Change in x wind due to model physics per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_y_wind"
                    description="Change in y wind per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_y_wind_due_to_model_physics"
                    description="Change in y wind due to model physics per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_eastward_wind"
                    description="Change in eastward wind per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_eastward_wind_due_to_model_physics"
                    description="Change in eastward wind due to model physics per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_northward_wind"
                    description="Change in northward wind per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="tendency_of_northward_wind_due_to_model_physics"
                    description="Change in northward wind due to model physics per unit time">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
     <standard_name name="horizontal_streamfunction_of_air"
                    description="Scalar function describing the streamlines of the horizontal wind">
-      <type kind="kind_phys" units="m2 s-1">real</type>
+      <type units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="horizontal_velocity_potential_of_air"
                    description="Scalar potential of the horizontal wind">
-      <type kind="kind_phys" units="m2 s-1">real</type>
+      <type units="m2 s-1">real</type>
     </standard_name>
     <standard_name name="upward_absolute_vorticity_of_air"
                    description="The upward (kth) component of the curl of the vector wind field">
-      <type kind="kind_phys" units="s-1">real</type>
+      <type units="s-1">real</type>
     </standard_name>
     <standard_name name="horizontal_divergence_of_air"
                    description="The horizontal divergence of the 2-D vector wind field">
-      <type kind="kind_phys" units="s-1">real</type>
+      <type units="s-1">real</type>
     </standard_name>
     <standard_name name="upward_heat_flux_in_air_at_surface">
-      <type kind="kind_phys" units="W m-2">real</type>
+      <type units="W m-2">real</type>
     </standard_name>
     <standard_name name="cumulative_boundary_flux_of_total_energy">
-      <type kind="kind_phys" units="W m-2">real</type>
+      <type units="W m-2">real</type>
     </standard_name>
     <standard_name name="cumulative_boundary_flux_of_total_water">
-      <type kind="kind_phys" units="W m-2">real</type>
+      <type units="W m-2">real</type>
     </standard_name>
     <standard_name name="us_standard_air_pressure_at_sea_level"
                    description="US Standard Atmospheric pressure at sea level">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="surface_reference_pressure"
                    description="Reference pressure used in definition of some other quantity (e.g. potential temperature, Exner function, etc.)">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_pressure_in_atmosphere_layer">
-      <type kind="kind_phys" units="Pa">real</type>
+      <type units="Pa">real</type>
     </standard_name>
     <standard_name name="reference_air_pressure_normalized_by_air_pressure_at_surface"
                    description="reference pressure normalized by surface pressure">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="reference_pressure_in_atmosphere_layer_normalized_by_surface_reference_pressure"
                    description="Reference pressure in atmosphere layer normalized by surface reference pressure">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="exner_function"
                    description="exner function, (p/p0)^(Rd/cp), where p0 is 1000 hPa">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="potential_temperature_of_air"
                    description="air potential temperature">
-      <type kind="kind_phys" units="K">real</type>
+      <type units="K">real</type>
     </standard_name>
     <standard_name name="potential_temperature_of_air_on_previous_timestep"
                    description="air potential temperature on previous timestep">
-      <type kind="kind_phys" units="K">real</type>
+      <type units="K">real</type>
     </standard_name>
     <standard_name name="composition_dependent_gas_constant_of_dry_air">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+      <type units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name name="composition_dependent_specific_heat_of_dry_air_at_constant_pressure"
                    description="composition-dependent specific heat of dry air at constant pressure">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+      <type units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name name="composition_dependent_ratio_of_dry_air_gas_constant_to_specific_heat_of_dry_air_at_constant_pressure"
                    description="composition-dependent ratio of dry air gas constant to specific heat of dry air at constant pressure">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="ratio_of_water_vapor_gas_constant_to_composition_dependent_dry_air_gas_constant_minus_one"
         description="Ratio of gas constants of water vapor to composition-dependent dry air minus one; (Rwv / Rdair) - 1.0">
-      <type kind="kind_phys" units="1">real</type>
+      <type units="1">real</type>
     </standard_name>
     <standard_name name="mass_content_of_cloud_ice_in_atmosphere_layer">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="mass_content_of_cloud_liquid_water_in_atmosphere_layer">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="mass_content_of_rain_in_atmosphere_layer">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="mass_content_of_snow_in_atmosphere_layer">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="mass_content_of_graupel_in_atmosphere_layer">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="mass_content_of_hail_in_atmosphere_layer">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name
         name="nonconvective_cloud_area_fraction_in_atmosphere_layer"
         description="cloud area fraction in atmosphere layer excluding clouds produced by the convective schemes">
-      <type kind="kind_phys" units="fraction">real</type>
+      <type units="fraction">real</type>
     </standard_name>
     <standard_name name="relative_humidity">
-      <type kind="kind_phys" units="fraction">real</type>
+      <type units="fraction">real</type>
     </standard_name>
     <standard_name name="relative_humidity_at_2m">
-      <type kind="kind_phys" units="fraction">real</type>
+      <type units="fraction">real</type>
     </standard_name>
     <standard_name name="gravitational_acceleration">
-      <type kind="kind_phys" units="m s-2">real</type>
+      <type units="m s-2">real</type>
     </standard_name>
   </section>
   <section name="land_surface">
     <standard_name name="land_ice_area_fraction_of_cell_area"
                    description="fraction of horizontal area of grid cell that is ice over land">
-      <type kind="kind_phys" units="frac">real</type>
+      <type units="frac">real</type>
     </standard_name>
     <standard_name name="mass_content_of_water_in_top_soil_layer"
                    description="mass per unit area of water in top layer of soil">
-      <type kind="kind_phys" units="kg m-2">real</type>
+      <type units="kg m-2">real</type>
     </standard_name>
     <standard_name name="density_of_snow_at_surface">
-      <type kind="kind_phys" units="kg m-3">real</type>
+      <type units="kg m-3">real</type>
     </standard_name>
     <standard_name name="urban_area_fraction_of_cell_area"
                    description="fraction of horizontal area of grid cell that is urban">
-      <type kind="kind_phys" units="frac">real</type>
+      <type units="frac">real</type>
     </standard_name>
     <standard_name name="volume_fraction_of_liquid_water_in_soil_at_critical_point"
                    description="volume fraction of water in liquid phase in soil at critical point">
-      <type kind="kind_phys" units="m3 m-3">real</type>
+      <type units="m3 m-3">real</type>
     </standard_name>
     <standard_name name="volume_fraction_of_liquid_water_in_soil_at_saturation"
                    description="volume fraction of water in liquid phase in soil at saturation">
-      <type kind="kind_phys" units="m3 m-3">real</type>
+      <type units="m3 m-3">real</type>
     </standard_name>
     <standard_name name="volume_fraction_of_liquid_water_in_soil_at_wilting_point"
                    description="volume fraction of water in liquid phase in soil at wilting point">
-      <type kind="kind_phys" units="m3 m-3">real</type>
+      <type units="m3 m-3">real</type>
     </standard_name>
   </section>
   <section name="diagnostics">
     <standard_name name="total_precipitation_rate_at_surface">
-      <type kind="kind_phys" units="m s-1">real</type>
+      <type units="m s-1">real</type>
     </standard_name>
   </section>
   <section name="atmospheric_composition">
     <standard_name name="number_of_chemical_species">
-      <type kind="kind_phys" units="count">integer</type>
+      <type units="count">integer</type>
     </standard_name>
     <standard_name name="number_of_tracers">
-      <type kind="kind_phys" units="count">integer</type>
+      <type units="count">integer</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air"
                    description="Ratio of the mass of water vapor to the mass of moist air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water"
                    description="Ratio of the mass of water vapor to the mass of moist air and hydrometeors">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
                    description="Ratio of the mass of water vapor to the mass of moist air and hydrometeors at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mole_fraction_of_water_vapor">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_dry_air"
                    description="Ratio of the mass of water vapor to the mass of dry air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_dry_air_at_top_interfaces"
                    description="Ratio of the mass of water vapor to the mass of dry air at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water"
                    description="Ratio of the mass of cloud liquid water to the mass of moist air and condensed water">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
                    description="Ratio of the mass of cloud liquid water to the mass of moist air and condensed water at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air"
                    description="Ratio of the mass of cloud liquid water to the mass of moist air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_dry_air"
                    description="Ratio of the mass of cloud liquid water to the mass of dry air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_liquid_water_mixing_ratio_wrt_dry_air_at_top_interfaces"
                    description="Ratio of the mass of cloud liquid water to the mass of dry air at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water"
                    description="Ratio of the mass of cloud ice to the mass of moist air and condensed water">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
                    description="Ratio of the mass of cloud ice to the mass of moist air and condensed water at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_ice_mixing_ratio_wrt_dry_air"
                    description="Ratio of the mass of cloud ice to the mass of dry air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="cloud_ice_mixing_ratio_wrt_dry_air_at_top_interfaces"
                    description="Ratio of the mass of cloud ice to the mass of dry air at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_moist_air_and_condensed_water"
                    description="ratio of the mass of rain to the mass of moist air and condensed water">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
                    description="ratio of the mass of rain to the mass of moist air and condensed water at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_moist_air"
                    description="ratio of the mass of rain to the mass of moist air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_dry_air"
                    description="ratio of the mass of rain to the mass of dry air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="rain_mixing_ratio_wrt_dry_air_at_top_interfaces"
                    description="ratio of the mass of rain to the mass of dry air at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="total_water_mixing_ratio_wrt_moist_air_and_condensed_water"
                    description="ratio of the mass of all water phases to the mass of moist air and condensed water">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="total_water_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces"
                    description="ratio of the mass of all water phases to the mass of moist air and condensed water at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="total_water_mixing_ratio_wrt_dry_air"
                    description="ratio of the mass of all water phases to the mass of dry air">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="total_water_mixing_ratio_wrt_dry_air_at_top_interfaces"
                    description="ratio of the mass of all water phases to the mass of dry air at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_assuming_saturation"
                    description="saturated water vapor mass mixing ratio with respect to moist air and condensed water">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_top_interfaces_assuming_saturation"
                    description="saturated water vapor mass mixing ratio with respect to moist air and condensed water at all interfaces excluding surface">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature"
                    description="derivative of the natural logarithm of water vapor partial pressure at saturation with respect to air temperature">
-      <type kind="kind_phys" units="K-1">real</type>
+      <type units="K-1">real</type>
     </standard_name>
     <standard_name name="derivative_of_ln_water_vapor_partial_pressure_assuming_saturation_wrt_air_temperature_at_top_interfaces"
                    description="derivative of the natural logarithm of water vapor partial pressure at saturation with respect to air temperature at all interfaces excluding surface">
-      <type kind="kind_phys" units="K-1">real</type>
+      <type units="K-1">real</type>
     </standard_name>
     <standard_name name="mole_fraction_of_ozone_in_air">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="mole_fraction_of_co2_in_air">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ch4"
                    description="Methane volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_co"
                    description="Carbon monoxide volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_co2"
                    description="Carbon dioxide volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_ccl4"
                    description="Tetrachloromethane volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc11"
                    description="Trichlorofluoromethane volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc12"
                    description="Dichlorodifluoromethane volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc113"
                    description="1,1,2-Trichloro-1,2,2-trifluoroethane volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_cfc22"
                    description="Chlorodifluoromethane volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_o2"
                    description="Dioxygen volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_n2o"
                    description="Nitrous oxide volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_no2"
                    description="Nitrogen dioxide volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_no"
                    description="Nitric oxide volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_o3"
                    description="Ozone volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_hcho"
                    description="Formaldehyde volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_c5h8"
                    description="Isoprene volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
     <standard_name name="volume_mixing_ratio_of_so2"
                    description="Sulfur dioxide volume mixing ratio">
-      <type kind="kind_phys" units="mol mol-1">real</type>
+      <type units="mol mol-1">real</type>
     </standard_name>
   </section>
     <section name="atmospheric_composition: GOCART aerosols">
     <standard_name name="mass_fraction_of_dust001_in_air"
                    description="Dust bin1 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_dust002_in_air"
                    description="Dust bin2 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_dust003_in_air"
                    description="Dust bin3 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_dust004_in_air"
                    description="Dust bin4 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_dust005_in_air"
                    description="Dust bin5 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_salt001_in_air"
                    description="Sea salt bin1 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_salt002_in_air"
                    description="Sea salt bin2 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_salt003_in_air"
                    description="Sea salt bin3 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_salt004_in_air"
                    description="Sea salt bin4 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_salt005_in_air"
                    description="Sea salt bin5 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_hydrophobic_black_carbon_in_air"
                    description="Hydrophobic black carbon mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_hydrophilic_black_carbon_in_air"
                    description="Hydrophilic black carbon mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_hydrophobic_organic_carbon_in_air"
                    description="Hydrophobic organic carbon mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_hydrophilic_organic_carbon_in_air"
                    description="Hydrophilic organic carbon mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sulfate_in_air"
                    description="Sulfate mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_nitrate001_in_air"
                    description="Nitrate bin1 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_nitrate002_in_air"
                    description="Nitrate bin2 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="mass_fraction_of_sea_nitrate003_in_air"
                    description="Nitrate bin3 mass fraction">
-      <type kind="kind_phys" units="kg kg-1">real</type>
+      <type units="kg kg-1">real</type>
     </standard_name>
     <standard_name name="volume_extinction_in_air_due_to_aerosol_particles_lambda1"
                    description="Aerosol extinction at wavelength1">
-      <type kind="kind_phys" units="m-1">real</type>
+      <type units="m-1">real</type>
     </standard_name>
     <standard_name name="volume_extinction_in_air_due_to_aerosol_particles_lambda2"
                    description="Aerosol extinction at wavelength2">
-      <type kind="kind_phys" units="m-1">real</type>
+      <type units="m-1">real</type>
     </standard_name>
     <standard_name name="volume_extinction_in_air_due_to_aerosol_particles_lambda3"
                    description="Aerosol extinction at wavelength3">
-      <type kind="kind_phys" units="m-1">real</type>
+      <type units="m-1">real</type>
     </standard_name>
   </section>
   <section name="emissions"
            comment="Emissions variables, contributed for the Community Emissions Data System (CEDS)">
     <standard_name name="emissions_of_co_due_to_anthropogenic_sources"
                    description="Carbon monoxide emissions from anthropogenic sources, total">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_sources"
                    description="Nitric oxide emissions from anthropogenic sources, total">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_sources"
                    description="Formaldehyde emissions from anthropogenic sources, total">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_agriculture"
                    description="Carbon monoxide emissions from anthropogenic non-combustion agricultural sector">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_agriculture"
                    description="Nitric oxide emissions from anthropogenic non-combustion agricultural sector">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_agriculture"
                    description="Formaldehyde emissions from anthropogenic non-combustion agricultural sector">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_energy"
                    description="Carbon monoxide emissions from anthropogenic non-combustion energy transformation and extraction">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_energy"
                    description="Nitric oxide emissions from anthropogenic non-combustion energy transformation and extraction">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_energy"
                    description="Formaldehyde emissions from anthropogenic non-combustion energy transformation and extraction">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_industry"
                    description="Carbon monoxide emissions from anthropogenic industrial combustion and processes">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_industry"
                    description="Nitric oxide emissions from anthropogenic industrial combustion and processes">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_industry"
                    description="Formaldehyde emissions from anthropogenic industrial combustion and processes">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_rco"
                    description="Carbon monoxide emissions from anthropogenic residential, commercial, and others">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_rco"
                    description="Nitric oxide emissions from anthropogenic residential, commercial, and others">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_rco"
                    description="Formaldehyde emissions from anthropogenic residential, commercial, and others">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_shipping"
                    description="Carbon monoxide emissions from anthropogenic international shipping">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_shipping"
                    description="Nitric oxide emissions from anthropogenic international shipping">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_shipping"
                    description="Formaldehyde emissions from anthropogenic international shipping">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_solvents"
                    description="Carbon monoxide emissions from anthropogenic solvents">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_solvents"
                    description="Nitric oxide emissions from anthropogenic solvents">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_solvents"
                    description="Formaldehyde emissions from anthropogenic solvents">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_transportation"
                    description="Carbon monoxide emissions from anthropogenic surface transportation (road, rail, other)">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_transportation"
                    description="Nitric oxide emissions from anthropogenic surface transportation (road, rail, other)">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_transportation"
                    description="Formaldehyde emissions from anthropogenic surface transportation (road, rail, other)">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_co_due_to_anthropogenic_waste"
                    description="Carbon monoxide emissions from anthropogenic waste disposal and handling">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_no_due_to_anthropogenic_waste"
                    description="Nitric oxide emissions from anthropogenic waste disposal and handling">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
     <standard_name name="emissions_of_hcho_due_to_anthropogenic_waste"
                    description="Formaldehyde emissions from anthropogenic waste disposal and handling">
-      <type kind="kind_phys" units="kg m-2 s-1">real</type>
+      <type units="kg m-2 s-1">real</type>
     </standard_name>
   </section>
   <section name="Application-specific variables">
@@ -1385,42 +1385,42 @@
              comment="Required CCPP framework-provided variables">
       <standard_name name="ccpp_error_message"
                      description="Error message for error handling in CCPP">
-        <type kind="len=512" units="none">character</type>
+        <type units="none">character</type>
       </standard_name>
       <standard_name name="ccpp_error_code"
                      description="Error code for error handling in CCPP">
-        <type kind="" units="1">integer</type>
+        <type units="1">integer</type>
       </standard_name>
     </section>
     <section name="optional framework-provided variables"
              comment="Optional CCPP framework-provided variables">
       <standard_name name="ccpp_scheme_name"
                      description="CCPP physics scheme name">
-        <type kind="len=64" units="none">character</type>
+        <type units="none">character</type>
       </standard_name>
       <standard_name name="ccpp_constituent_properties"
                      description="CCPP Constituent Properties">
-        <type kind="" units="none">ccpp_constituent_prop_ptr_t</type>
+        <type units="none">ccpp_constituent_prop_ptr_t</type>
       </standard_name>
       <standard_name name="ccpp_constituents"
                      description="Array of constituents managed by CCPP Framework">
-        <type kind="kind_phys" units="none">real</type>
+        <type units="none">real</type>
       </standard_name>
       <standard_name name="ccpp_constituent_min_values"
                      description="CCPP constituent minimum values">
-        <type kind="kind_phys" units="none">real</type>
+        <type units="none">real</type>
       </standard_name>
       <standard_name name="number_of_ccpp_constituents"
                      description="Number of constituents managed by CCPP Framework">
-        <type kind="" units="count">integer</type>
+        <type units="count">integer</type>
       </standard_name>
       <standard_name name="ccpp_block_count"
                      description="CCPP block count">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="ccpp_block_sizes"
                      description="CCPP block sizes">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="ccpp_thread_number"
                      description="Number of current OpenMP thread. This variable may only be used during CCPP run phase">
@@ -1432,2881 +1432,2881 @@
            comment="Variables related to the compute environment">
     <standard_name name="flag_for_mpi_root"
                    description="Flag for MPI root process">
-      <type kind="" units="flag">logical</type>
+      <type units="flag">logical</type>
     </standard_name>
     <standard_name name="log_output_unit"
                    description="Fortran logical unit for output log file">
-      <type kind="" units="1">integer</type>
+      <type units="1">integer</type>
     </standard_name>
   </section>
   <section name="GFS_typedefs_GFS_control_type">
       <standard_name name="sigma_pressure_hybrid_coordinate_a_coefficient">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="radiatively_active_gases_as_string">
-         <type kind="len=128" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="aerosol_aware_multiplicative_rain_conversion_parameter_for_deep_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="aerosol_aware_multiplicative_rain_conversion_parameter_for_shallow_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="number_of_microphysics_variables_in_xy_dimensioned_restart_array">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_microphysics_variables_in_xyz_dimensioned_restart_array">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_random_numbers">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="multiplicative_tuning_parameter_for_atmosphere_diffusivity">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="atmosphere_heat_diffusivity_due_to_background">
-         <type kind="kind_phys" units="m2 s-1">real</type>
+         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="max_atmosphere_heat_diffusivity_due_to_background"
                    description="Maximum atmosphere heat diffusivity due to background">
-         <type kind="kind_phys" units="m2 s-1">real</type>
+         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="atmosphere_momentum_diffusivity_due_to_background">
-         <type kind="kind_phys" units="m2 s-1">real</type>
+         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="sigma_pressure_hybrid_coordinate_b_coefficient">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="cellular_automata_finer_grid">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="cellular_automata_lifetime">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="cellular_automata_seed_frequency">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="cellular_automata_seed_probability">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="identifier_for_2018_scale_aware_tke_moist_edmf_pbl"
                    description="Identifier for 2018 scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_scale_aware_tke_moist_edmf_pbl_scheme"
                    description="Control for scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_2019_scale_aware_tke_moist_edmf_pbl"
                    description="Identifier for 2019 scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="cloud_condensate_autoconversion_threshold_coefficient">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="cloud_condensate_autoconversion_threshold_coefficient_for_deep_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="control_for_cloud_area_fraction_option">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="reciprocal_of_cloud_phase_transition_temperature_range">
-         <type kind="kind_phys" units="K-1">real</type>
+         <type units="K-1">real</type>
       </standard_name>
       <standard_name name="cloud_phase_transition_threshold_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="control_for_cloud_species_mixing_in_mynn_pbl_scheme"
                    description="Control for cloud species mixing in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_cloud_pdf_in_mynn_pbl_scheme"
                    description="Control for cloud probability density function in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="precipitation_evaporation_coefficient">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="coefficient_for_variable_bulk_richardson_number_over_land">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="coefficient_for_variable_bulk_richardson_number_over_water">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="autoconversion_to_snow_coefficient">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="autoconversion_to_snow_coefficient_for_deep_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="autoconversion_to_rain_coefficient">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="autoconversion_to_rain_coefficient_for_deep_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="chemical_tracer_scavenging_fractions">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="cloud_condensate_detrainment_coefficient">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="control_for_convective_cloud_diagnostics">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="cosine_of_solar_declination_angle">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="control_for_sgs_cloud_radiation_coupling_in_mynn_pbl_scheme"
                    description="Control for subgrid-scale cloud radiation coupling in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="tunable_parameter_for_critical_cloud_top_entrainment_instability_criteria">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="critical_relative_humidity_at_top_of_atmosphere_boundary_layer">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="critical_relative_humidity_at_surface">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="critical_relative_humidity_at_toa"
                    description="Critical relative humidity at the top of the atmosphere">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="date_and_time_at_model_initialization_in_iso_order">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="date_and_time_at_model_initialization_in_united_states_order">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="decorrelation_length_used_by_overlap_method">
-         <type kind="kind_phys" units="km">real</type>
+         <type units="km">real</type>
       </standard_name>
       <standard_name name="density_of_fresh_water">
-         <type kind="kind_phys" units="kg m-3">real</type>
+         <type units="kg m-3">real</type>
       </standard_name>
       <standard_name name="depth_of_soil_layers">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="tunable_parameter_1_for_detrainment_and_precipitation_partitioning_in_chikira_sugiyama_deep_convection">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="tunable_parameter_2_for_detrainment_and_precipitation_partitioning_in_chikira_sugiyama_deep_convection">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="detrainment_conversion_parameter_for_deep_convection">
-         <type kind="kind_phys" units="m-1">real</type>
+         <type units="m-1">real</type>
       </standard_name>
       <standard_name name="detrainment_conversion_parameter_for_shallow_convection">
-         <type kind="kind_phys" units="m-1">real</type>
+         <type units="m-1">real</type>
       </standard_name>
       <standard_name name="do_unified_gravity_wave_physics_diagnostics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_chemical_tracer_diagnostics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="sigma_pressure_threshold_at_upper_extent_of_background_diffusion">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="directory_for_rte_rrtmgp_source_code"
                    description="Directory for Radiative Transfer for Energetics/Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) source code">
-         <type kind="len=128" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="do_myj_pbl_scheme"
                    description="Do Mellor-Yamada-Janjic planetary boundary layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_myj_surface_layer_scheme"
                    description="Do Mellor-Yamada-Janjic surface layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_mynn_pbl_scheme"
                    description="Do Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_mynn_surface_layer_scheme"
                    description="Do Mellor-Yamada-Nakanishi-Niino surface layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_unified_gravity_wave_physics_gwd_scheme"
                    description="Do Unifed Gravity Wave Physics gravity wave drag scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="downdraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme"
                    description="Downdraft area fraction in scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="downdraft_fraction_reaching_surface_over_land_for_deep_convection">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="downdraft_fraction_reaching_surface_over_water_for_deep_convection">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="control_for_edmf_in_mynn_pbl_scheme"
                    description="Control for eddy-diffusivity mass flux in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_edmf_momentum_transport_in_mynn_pbl_scheme"
                    description="Control for eddy-diffusivity mass flux momentum transport in Mellor-Yamada-Nakanishi-Niino surface layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_edmf_partitioning_in_mynn_pbl_scheme"
                    description="Control for eddy-diffusivity mass flux partitioning in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_edmf_tke_transport_in_mynn_pbl_scheme"
                    description="Control for eddy-diffusivity mass flux turbulent kinetic energy transport in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="surface_layer_scheme_enthalpy_flux_factor">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="tunable_parameter_for_entrainment_efficiency_in_chikira_sugiyama_deep_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="entrainment_rate_coefficient_for_deep_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="entrainment_rate_coefficient_for_shallow_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="equation_of_time">
-         <type kind="kind_phys" units="radian">real</type>
+         <type units="radian">real</type>
       </standard_name>
       <standard_name name="relative_humidity_threshold_for_condensation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="do_arakawa_wu_downdrafts_for_deep_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_debug_output">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_diagnostics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_xyz_dimensioned_diagnostics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_flip">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_flux_adjusting_surface_data_assimilation_system">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_flux_form_in_chikira_sugiyama_deep_convection_scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_nrl_2015_ozone_scheme"
                    description="Do Naval Research Laboratory 2015 ozone scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_prescribed_aerosols">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_aerosol_physics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_arakawa_wu_adjustment">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_canopy_heat_storage_in_land_surface_scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_canopy_stomatal_resistance">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_cellular_automata">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_chemistry_coupling">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_chikira_sugiyama_deep_convection_scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_in_cloud_condensate">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_cloud_effective_radii">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_cloud_overlap_method_for_radiation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_constant_decorrelation_length_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_convective_gwd"
                    description="Do convective gravity wave drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_convective_transport_of_tracers">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_converting_hydrometeors_from_moist_to_dry_air">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_crick_elimination">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_decorrelation_length_cloud_overlap_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_decorrelation_length_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_shortwave_radiation_aerosols">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_dynamic_vegetation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_exponential_cloud_overlap_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_exponential_random_cloud_overlap_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_fer_hires_microphysics_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="is_first_timestep">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_surface_flux_coupling">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_fractional_landmask">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_frozen_soil_permeability">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_cellular_automata_gaussian_spatial_filter">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_gcycle_surface_option">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_generic_tendency_due_to_deep_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_generic_tendency_due_to_gwd"
                    description="Do generic tendency due to gravity wave drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_generic_tendency_due_to_pbl"
                    description="Do generic tendency due to planetary boundary layer">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_generic_tendency_due_to_shallow_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_grell_freitas_deep_convection">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_grell_freitas_shallow_convection">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_gfdl_microphysics_radiation_interaction"
                    description="Do Geophysical Fluid Dynamics Laboratory microphysics radiation interaction">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_gfdl_microphysics_scheme"
                    description="Identifier for Geophysical Fluid Dynamics Laboratory microphysics scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_global_cellular_automata">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_global_cellular_automata_closure">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_global_cellular_automata_deep_convective_entrainment">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_global_cellular_automata_trigger">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_gwd"
                    description="Do gravity wave drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_surface_snow_albedo">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_gsl_drag_suite_large_scale_orographic_and_blocking_drag"
                    description="Do Global Systems Lab drag suite large-scale orographic and blocking drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_gsl_drag_suite_small_scale_orographic_drag"
                    description="Do Global Systems Lab drag suite small-scale orographic drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_gsl_drag_suite_turbulent_orographic_form_drag"
                    description="Do Global Systems Lab drag suite turbulent orographic form drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_hybrid_edmf_pbl_scheme"
                    description="Do hybrid eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_hogan_decorrelation_length_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_hurricane_specific_code_in_scale_aware_mass_flux_deep_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_hurricane_specific_code_in_scale_aware_mass_flux_shallow_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_hydrostatic_solver">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_ice_cloud_condensation_nuclei_forcing">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_separate_advection_of_condensate_species">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_initial_time_date">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_lake_surface_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_cloud_area_fraction_option_for_radiation">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_lower_boundary_soil_temperature">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_lw_clouds_subgrid_approximation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_deep_convection_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_shallow_convection_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_max_cloud_overlap_method"
                    description="Control for maximum cloud overlap method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_max_random_cloud_overlap_method"
                    description="Identifier for maximum random cloud overlap method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_microphysics_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_moorthi_stratus">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_morrison_gettelman_microphysics_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_mountain_blocking_for_sppt"
                    description="Do mountain blocking for stochastically perturbed physics tendencies">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_noah_land_surface_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_noah_lsm_ua_extension"
                    description="Do Noah land surface model University of Arizona extension">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_noah_wrfv4_land_surface_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_noahmp"
                    description="Identifier for Noah land surface model with multiparameterization options">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_nsstm_analysis_in_gcycle"
                    description="Do GFS near-surface sea temperature scheme analysis in gcycle">
 GFS near-surface sea temperature scheme
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_nsstm"
                    description="Control for GFS near-surface sea temperature scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_new_tiedtke_deep_convection">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_new_tiedtke_shallow_convection">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_surface_layer_scheme_ocean_currents">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_old_pbl_scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_optical_property_for_ice_clouds_for_longwave_radiation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_optical_property_for_ice_clouds_for_shortwave_radiation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_optical_property_for_liquid_clouds_for_longwave_radiation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_optical_property_for_liquid_clouds_for_shortwave_radiation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_oreopoulos_decorrelation_length_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_output_of_tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep_assuming_clear_sky">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_output_of_tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep_assuming_clear_sky">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_nrl_2006_ozone_scheme"
                    description="Do Naval Research Laboratory 2006 ozone scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_pdf_shape_for_microphysics"
                    description="Control for probability density function shape for microphysics">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_surface_layer_scheme_surface_drag_coefficient_for_momentum_in_air_perturbations">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="disable_precipitation_radiative_effect">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_precipitation_type_partition">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_dominant_precipitation_type_partition">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_radar_reflectivity">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_radiative_transfer">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_random_cloud_overlap_method">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_random_clouds_in_relaxed_arakawa_schubert_deep_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_relaxed_arakawa_schubert_deep_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_read_leaf_area_index_from_input">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_read_surface_albedo_for_diffused_shortwave_from_input">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_limited_roughness_length_over_ocean"
                    description="Do limited surface roughness length over ocean">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_reference_pressure_theta">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="is_restart">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_rrtmgp_radiation_scheme"
                    description="Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) radiation scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_ruc_land_surface_scheme"
                    description="Identifier for Rapid Update Cycle land surface scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_runoff_and_groundwater">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_scale_aware_mass_flux_deep_convection">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_scale_aware_mass_flux_shallow_convection">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_sas_deep_convection"
                    description="Identifier for Simplified Arakawa-Schubert deep convection scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_sas_shallow_convection"
                    description="Identifier for Simplified Arakawa-Schubert shallow convection scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_scale_aware_mass_flux_deep_convection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_scale_aware_shin_hong_pbl_scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_scale_aware_tke_moist_edmf_pbl"
                    description="Do scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_sgs_cellular_automata">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_sas_shallow_convection"
                    description="Do Simplified Arakawa-Schubert shallow convection scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_shoc"
                    description="Do Simplified Higher-Order Closure stochastic physics scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_shoc_after_convection"
                    description="Do Simplified Higher-Order Closure stochastic physics scheme after convection parameterization">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_soil_and_snow_temperature_time_integration">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_soil_moisture_factor_stomatal_resistance">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_solar_constant">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_stochastic_cloud_fraction_perturbations">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_stochastic_microphysics_perturbations">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_stochastic_physics_perturbations">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_stochastic_radiative_heating_perturbations">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_stochastic_shum_option"
                    description="Do Stochastic HUMidity stochastic physics option">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_stochastic_skeb_option"
                    description="Do Stochastic Kinetic Energy Backscatter option">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_stratospheric_water_vapor_physics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_supercooled_liquid_water">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_surface_emissivity">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_surface_layer_drag_coefficient">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_surface_roughness_option_over_water">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_sw_clouds_subgrid_approximation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_land_surface_scheme_thermal_conductivity_option">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_thompson_microphysics_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_ugwp_version_0"
                    description="Do Unified Gravity Wave Physics version 0">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_ugwp_version_0_nonorographic_gwd"
                    description="Do Unified Gravity Wave Physics version 0 non-orographic gravity wave drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_ugwp_version_0_orographic_gwd"
                    description="Do Unified Gravity Wave Physics version 0 orographic gravity wave drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_ugwp_version_1"
                    description="Do Unified Gravity Wave Physics version 1">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_ugwp_version_1_nonorographic_gwd"
                    description="Do Unified Gravity Wave Physics version 1 non-orographic gravity wave drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_ugwp_version_1_orographic_gwd"
                    description="Do Unified Gravity Wave Physics version 1 orographic gravity wave drag">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_shoc_cloud_area_fraction_for_radiation"
                    description="Do Simplified Higher-Order Closure stochastic physics scheme cloud area fraction for radiation">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_surface_layer_scheme_skin_temperature_update">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_surface_albedo">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_prescribed_co2">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_vertical_index_direction">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_ocean_wave_coupling">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_one_way_ocean_wave_coupling_to_atmosphere">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_wsm6_microphysics_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_ysu_pbl_scheme"
                    description="Do Yonsei University (YSU) planetary boundary layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="identifier_for_zhao_carr_microphysics_scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="identifier_for_zhao_carr_pdf_microphysics_scheme"
                    description="Identifier for Zhao-Carr probability density function microphysics scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="do_hurricane_specific_code_in_hybrid_edmf_pbl_scheme"
                    description="Do hurricane-specific code in hybrid eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_integrated_dynamics_through_earths_atmosphere">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_print">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_save_shallow_convective_cloud_area_fraction">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_tke_dissipation_heating">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_call_longwave_radiation">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_rrtmg_cloud_optics"
                    description="Flag for Rapid Radiative Transfer Model for General circulation model applications (RRTMG) cloud optics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_rrtmgp_cloud_optics_lookup_table"
                    description="Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) cloud optics lookup table">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_rrtmgp_cloud_optics_with_pade_approximation"
                    description="Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) with Pade approximation">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_rrtmgp_longwave_jacobian"
                    description="Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave jacobian">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_call_shortwave_radiation">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_longwave_scattering_in_cloud_optics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_tracer_xyz_dimensioned_diagnostics">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_variable_bulk_richardson_number">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="date_and_time_of_forecast_in_united_states_order">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="forecast_utc_hour">
-         <type kind="kind_phys" units="h">real</type>
+         <type units="h">real</type>
       </standard_name>
       <standard_name name="forecast_time">
-         <type kind="kind_phys" units="h">real</type>
+         <type units="h">real</type>
       </standard_name>
       <standard_name name="forecast_time_on_previous_timestep">
-         <type kind="kind_phys" units="h">real</type>
+         <type units="h">real</type>
       </standard_name>
       <standard_name name="period_of_longwave_radiation_calls">
-         <type kind="kind_phys" units="s">real</type>
+         <type units="s">real</type>
       </standard_name>
       <standard_name name="period_of_shortwave_radiation_calls">
-         <type kind="kind_phys" units="s">real</type>
+         <type units="s">real</type>
       </standard_name>
       <standard_name name="all_ice_cloud_threshold_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="control_for_gravitational_settling_of_cloud_droplets">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_drag_suite_gwd"
                    description="Control for drag option in gravity wave drag scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="horizontal_loop_extent">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="period_of_diagnostics_reset">
-         <type kind="kind_phys" units="h">real</type>
+         <type units="h">real</type>
       </standard_name>
       <standard_name name="tunable_parameter_for_ice_supersaturation">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="index_of_ice_vegetation_category">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="vertical_dimension_of_sea_ice">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="index_of_air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_air_temperature_two_timesteps_back_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_nonconvective_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_cloud_liquid_water_effective_radius_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_convective_cloud_area_fraction_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_convective_cloud_condensate_mixing_ratio_wrt_moist_air_in_xyz_dimensioned_restart_array"
                    description="Index of convective cloud condensate mass mixing ratio with respect to moist air in the XYZ-dimensioned restart array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_horizontal_gridpoint_for_debug_output">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_first_chemical_tracer_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_graupel_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
                    description="Index of graupel mass mixing ratio with respect to moist air in the tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_graupel_effective_radius_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_cloud_ice_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
                    description="Index of cloud ice mass mixing ratio with respect to moist air in the tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_cloud_ice_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_cloud_ice_effective_radius_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_cloud_liquid_water_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
                    description="Index of cloud liquid water mass mixing ratio with respect to moist air in the tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_cloud_droplets_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_weighted_rime_factor_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_ozone_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
                    description="Index of ozone mass mixing ratio with respect to moist air in the tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_rain_effective_radius_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_rain_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_rain_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
                    description="Index of rain mass mixing ratio with respect to moist air in the tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_snow_effective_radius_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_snow_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_snow_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
                    description="Index of snow mass mixing ratio with respect to moist air in the tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array"
                    description="Index of specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in xyz dimensioned restart array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back_in_xyz_dimensioned_restart_array"
                    description="Index of specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back in xyz dimensioned restart array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="control_for_stochastic_land_surface_perturbation">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="index_of_air_pressure_at_surface_on_previous_timestep_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_air_pressure_at_surface_two_timesteps_back_in_xyz_dimensioned_tracer_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convectionin_in_xy_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_tke_in_tracer_concentration_array"
                    description="Index of turbulent kinetic energy in tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_mass_number_concentration_of_hygroscopic_aerosols_in_tracer_concentration_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_water_vapor_mixing_ratio_wrt_moist_air_in_tracer_concentration_array"
                    description="Index of specific humidity (water vapor mass mixing ratio with respect to moist air) in tracer concentration array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_atmosphere_heat_diffusivity_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_upward_virtual_potential_temperature_flux_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_subgrid_cloud_area_fraction_in_atmosphere_layer_in_xyz_dimensioned_restart_array">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="index_of_timestep">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="reciprocal_of_grid_scale_range">
-         <type kind="kind_phys" units="rad2 m-2">real</type>
+         <type units="rad2 m-2">real</type>
       </standard_name>
       <standard_name name="iounit_of_log">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="iounit_of_namelist">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="forecast_julian_day">
-         <type kind="kind_phys" units="days">real</type>
+         <type units="days">real</type>
       </standard_name>
       <standard_name name="min_lake_ice_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="multiplicative_tuning_parameter_for_reduced_latent_heat_flux_due_to_canopy_heat_storage">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="max_tendency_of_potential_temperature_of_air_due_to_large_scale_precipitation"
                    description="Maximum tendency of air potential temperature due to large-scale precipitation">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="lower_bound_of_vertical_dimension_of_surface_snow">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="land_surface_perturbation_magnitudes">
-         <type kind="kind_phys" units="variable">real</type>
+         <type units="variable">real</type>
       </standard_name>
       <standard_name name="max_critical_relative_humidity"
                    description="Maximum critical relative humidity">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="max_grid_scale"
                    description="Maximum grid scale">
-         <type kind="kind_phys" units="m2 rad-2">real</type>
+         <type units="m2 rad-2">real</type>
       </standard_name>
       <standard_name name="max_soil_moisture_content_for_lsm"
                    description="Maximum soil moisture content for land surface model">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="do_allow_supersaturation_after_sedimentation">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="autoconversion_to_snow_size_threshold">
-         <type kind="kind_phys" units="um">real</type>
+         <type units="um">real</type>
       </standard_name>
       <standard_name name="bergeron_findeisen_process_efficiency_factor">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="relative_variance_of_subgrid_cloud_condensate_distribution">
-         <type kind="kind_phys" units="kg2 kg-2">real</type>
+         <type units="kg2 kg-2">real</type>
       </standard_name>
       <standard_name name="prescribed_number_concentration_of_cloud_droplets">
-         <type kind="kind_phys" units="m-3">real</type>
+         <type units="m-3">real</type>
       </standard_name>
       <standard_name name="do_prescribed_number_concentration_of_cloud_droplets">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_cloud_ice_processes">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_gmao_autoconversion_to_snow">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_graupel_instead_of_hail">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_hail_instead_of_graupel">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_heterogeneous_nucleation">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_liu_autoconversion_to_rain">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_seifert_and_beheng_2001_autoconversion">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_uniform_subcolumns">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_prescribed_number_concentration_of_graupel">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="do_prescribed_number_concentration_of_cloud_ice">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="prescribed_number_concentration_of_graupel">
-         <type kind="kind_phys" units="m-3">real</type>
+         <type units="m-3">real</type>
       </standard_name>
       <standard_name name="prescribed_number_concentration_of_cloud_ice">
-         <type kind="kind_phys" units="m-3">real</type>
+         <type units="m-3">real</type>
       </standard_name>
       <standard_name name="min_cloud_condensate_mixing_ratio_wrt_moist_air_threshold"
                    description="Minimum threshold cloud condensate mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="min_cloud_liquid_water_mixing_ratio_wrt_moist_air_threshold"
                    description="Minimum threshold cloud liquid water mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="min_cloud_ice_mixing_ratio_wrt_moist_air_threshold"
                    description="Minimum threshold cloud ice mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="relative_humidity_threshold_for_ice_nucleation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="timescale_for_autoconversion_to_snow">
-         <type kind="kind_phys" units="s">real</type>
+         <type units="s">real</type>
       </standard_name>
       <standard_name name="alpha_tuning_coefficient_for_morrison_gettelman_microphysics_scheme">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="control_for_precipitation_area_fraction_method">
-         <type kind="len=16" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="min_large_ice_fraction"
                    description="Minimum large ice fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="min_pressure_in_rrtmgp"
                    description="Minimum pressure in Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP)">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="min_grid_scale">
-         <type kind="kind_phys" units="m2 rad-2">real</type>
+         <type units="m2 rad-2">real</type>
       </standard_name>
       <standard_name name="min_soil_moisture_content_for_lsm"
                    description="Minimum soil moisture content for land surface model">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="min_temperature_in_rrtmgp"
                    description="Minimum temperature in Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP)">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="control_for_total_water_mixing_in_mynn_pbl_scheme"
                    description="Control for total water mixing in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_mixing_length_in_mynn_pbl_scheme"
                    description="Control for mixing length in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="momentum_transport_reduction_factor_due_to_pressure_gradient_force_for_deep_convection">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="momentum_transport_reduction_factor_due_to_pressure_gradient_force_for_shallow_convection">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="mpi_communicator">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="mpi_rank">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="mpi_root">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="number_of_mpi_tasks">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="tunable_parameter_for_critical_cloud_workfunction_in_relaxed_arakawa_schubert_deep_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="tunable_parameters_for_convective_gwd"
                    description="Tunable parameters for convective gravity wave drag">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="multiplicative_tunable_parameters_for_mountain_blocking_and_orographic_gwd"
                    description="Multiplicative tunable parameters for mountain blocking and orographic gravity wave drag">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="control_for_additional_diagnostics_in_mynn_pbl_scheme"
                    description="Control for additional diagnostics in Mellor-Yamada-Nakanishi-Niino planetary boundary layer scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="filename_of_namelist">
-         <type kind="len=64" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="filename_of_internal_namelist">
-         <type kind="len=256" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="number_of_xy_dimensioned_auxiliary_arrays">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_pdf_based_variables_in_xyz_dimensioned_restart_array"
                    description="Number of probability density function-based variables in XYZ-dimensioned restart array">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_xyz_dimensioned_auxiliary_arrays">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_radiatively_active_gases">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_aerosol_tracers">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_gaussian_quadrature_angles_for_radiation">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_chemical_tracers">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_condensate_species">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_cloud_types_in_chikira_sugiyama_deep_convection">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_convective_cloud_variables_in_xyz_dimensioned_restart_array">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_days_in_current_year">
-         <type kind="" units="days">integer</type>
+         <type units="days">integer</type>
       </standard_name>
       <standard_name name="number_of_equatorial_longitude_points">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_variables_in_xy_dimensioned_restart_array">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_variables_in_xyz_dimensioned_restart_array">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_frozen_precipitation_species">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_hydrometeors">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_independent_cellular_automata">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_iterations_to_spin_up_cellular_automata">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_perturbed_land_surface_variables">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_latitude_points">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_lines_in_internal_namelist">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_longwave_bands">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_longwave_spectral_points">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_x_points_for_current_cubed_sphere_tile">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_x_points_for_current_mpi_rank">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_y_points_for_current_cubed_sphere_tile">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_y_points_for_current_mpi_rank">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_diagnostics_variables_for_radiation">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_ice_roughness_categories">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_spectral_wave_truncation_for_sas_convection"
                    description="Number of spectral wave truncation for Simplified Arakawa-Schubert deep convection scheme">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_statistical_measures_of_subgrid_orography">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_shortwave_bands">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_shortwave_spectral_points">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="index_of_cubed_sphere_tile">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="number_of_timesteps_between_diagnostics_resetting">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_timesteps_between_longwave_radiation_calls">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_timesteps_between_shortwave_radiation_calls">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_timesteps_between_surface_cycling_calls">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_timesteps_for_concurrent_radiation_and_remainder_physics_calls_after_model_initialization">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="number_of_tracers_plus_one">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="vertical_dimension_for_radiation">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="vertical_interface_dimension_for_radiation">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="multiplicative_tuning_parameter_for_potential_evaporation">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="air_pressure_at_bottom_extent_of_rayleigh_damping">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="rain_conversion_parameter_for_deep_convection">
-         <type kind="kind_phys" units="m-1">real</type>
+         <type units="m-1">real</type>
       </standard_name>
       <standard_name name="rain_conversion_parameter_for_shallow_convection">
-         <type kind="kind_phys" units="m-1">real</type>
+         <type units="m-1">real</type>
       </standard_name>
       <standard_name name="rain_evaporation_coefficient_over_ocean_for_deep_convection">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="rain_evaporation_coefficient_over_land_for_deep_convection">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="filename_of_rrtmgp_longwave_cloud_optics_coefficients"
                    description="File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave cloud optics coefficients">
-         <type kind="len=128" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="filename_of_rrtmgp_shortwave_cloud_optics_coefficients"
                    description="File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) shortwave cloud optics coefficients">
-         <type kind="len=128" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="filename_of_rrtmgp_longwave_k_distribution"
                    description="File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave k-distribution">
-         <type kind="len=128" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="filename_of_rrtmgp_shortwave_k_distribution"
                    description="File name of Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) shortwave k-distribution">
-         <type kind="len=128" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="do_rrtmgp_shortwave_and_rrtmg_longwave_radiation"
                    description="Flag for Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) shortwave and Rapid Radiative Transfer Model for global climate model (GCM) applications (RRTMG) longwave radiation schemes">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="min_sea_ice_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="forecast_time_in_seconds">
-         <type kind="kind_phys" units="s">real</type>
+         <type units="s">real</type>
       </standard_name>
       <standard_name name="random_number_seed_for_cellular_automata">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="random_number_seed_for_deep_convection">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="control_for_tke_dissipation_method">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="uncentering_coefficient_for_implicit_tke_integration">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="pressure_threshold_for_increased_tke_dissipation">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="multiplicative_tunable_parameter_for_tke_dissipation">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="multiplicative_tunable_parameter_for_tke_dissipation_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="sine_of_solar_declination_angle">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="vertical_dimension_of_surface_snow">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="control_for_soil_type_dataset">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="vertical_dimension_of_soil">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="vertical_dimension_of_soil_internal_to_land_surface_scheme">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="solar_constant">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="starting_x_index_for_current_mpi_rank">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="starting_y_index_for_current_mpi_rank">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="multiplicative_tuning_parameter_for_reduced_surface_heat_fluxes_due_to_canopy_heat_storage">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="thickness_of_soil_layers_for_lsm"
                    description="Thickness of soil layers for land surface model">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="cellular_automata_vertical_velocity_perturbation_threshold_for_deep_convection">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="period_of_max_diagnostics_reset"
                    description="Period of maximum diagnostics reset">
-         <type kind="kind_phys" units="s">real</type>
+         <type units="s">real</type>
       </standard_name>
       <standard_name name="timescale_for_rayleigh_damping">
-         <type kind="kind_phys" units="d">real</type>
+         <type units="d">real</type>
       </standard_name>
       <standard_name name="time_elapsed_since_diagnostics_reset">
-         <type kind="kind_phys" units="h">real</type>
+         <type units="h">real</type>
       </standard_name>
       <standard_name name="timestep_for_dynamics">
-         <type kind="kind_phys" units="s">real</type>
+         <type units="s">real</type>
       </standard_name>
       <standard_name name="do_tke_advection">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="control_for_tke_budget_output">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="multiplicative_tuning_parameter_for_tke_dissipative_heating">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="total_amplitude_of_sppt_perturbation"
                    description="Total amplitude of stochastically perturbed physics tendencies perturbation">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="do_turbulent_orographic_form_drag_in_unified_gravity_wave_physics_gwd_scheme"
                    description="Do turbulent orographic form drag in Unified Gravity Wave Physics gravity wave drag scheme">
-         <type kind="" units="flag">logical</type>
+         <type units="flag">logical</type>
       </standard_name>
       <standard_name name="updraft_area_fraction_in_scale_aware_tke_moist_edmf_pbl_scheme"
                    description="Updraft area fraction in scale-aware turbulent kinetic energy moist eddy-diffusivity/mass-flux planetary boundary layer scheme">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="tunable_parameter_1_for_max_cloud_base_updraft_velocity_in_chikira_sugiyama_deep_convection">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="tunable_parameter_2_for_max_cloud_base_updraft_velocity_in_chikira_sugiyama_deep_convection">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="upper_bound_of_vertical_dimension_of_surface_snow">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="index_of_urban_vegetation_category">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="land_surface_perturbation_variables">
-         <type kind="len=3" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="control_for_vegetation_dataset">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="vertical_layer_dimension_minus_one">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="sigma_pressure_hybrid_vertical_coordinate">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="lower_bound_for_depth_of_sea_temperature_for_nsstm"
                    description="Lower bound for depth of sea temperature for GFS near-surface sea temperature scheme">
-         <type kind="" units="mm">integer</type>
+         <type units="mm">integer</type>
       </standard_name>
       <standard_name name="upper_bound_for_depth_of_sea_temperature_for_nsstm"
                    description="Upper bound for depth of sea temperature for GFS near-surface sea temperature scheme">
-         <type kind="" units="mm">integer</type>
+         <type units="mm">integer</type>
       </standard_name>
       <standard_name name="index_of_water_vegetation_category">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="filename_of_micm_configuration">
-         <type kind="len=*" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_interstitial_type">
       <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_interstitial"
                    description="Cloud ice mass mixing ratio with respect to moist air in interstitial scheme">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_interstitial"
                    description="Cloud liquid water mass mixing ratio with respect to moist air in interstitial scheme">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="radiatively_active_gases">
-         <type kind="len=128" units="none">character</type>
+         <type units="none">character</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_air_temperature">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_liquid_water_particles_in_air">
-         <type kind="kind_phys" units="kg-1 s-1">real</type>
+         <type units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_graupel_mixing_ratio_wrt_moist_air"
                    description="Process-split cumulative tendency of the graupel mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_cloud_ice_mixing_ratio_wrt_moist_air"
                    description="Process-split cumulative tendency of the cloud ice mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols">
-         <type kind="kind_phys" units="kg-1 s-1">real</type>
+         <type units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_cloud_ice_water_crystals_in_air">
-         <type kind="kind_phys" units="kg-1 s-1">real</type>
+         <type units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_cloud_liquid_water_mixing_ratio_wrt_moist_air"
                    description="Process-split cumulative tendency of the cloud liquid water mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_ozone_mixing_ratio_wrt_moist_air"
                    description="Process-split cumulative tendency of the ozone mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_rain_mixing_ratio_wrt_moist_air"
                    description="Process-split cumulative tendency of the rain mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_snow_mixing_ratio_wrt_moist_air"
                    description="Process-split cumulative tendency of the snow mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_tracers">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_tke"
                    description="Process-split cumulative change in turbulent kinetic energy per unit time">
-         <type kind="kind_phys" units="J s-1">real</type>
+         <type units="J s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_mass_number_concentration_of_hygroscopic_aerosols">
-         <type kind="kind_phys" units="kg-1 s-1">real</type>
+         <type units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_water_vapor_mixing_ratio_wrt_moist_air"
                    description="Process-split cumulative tendency of specific humidity (water vapor mass mixing ratio with respect to moist air)">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_x_wind">
-         <type kind="kind_phys" units="m s-2">real</type>
+         <type units="m s-2">real</type>
       </standard_name>
       <standard_name name="process_split_cumulative_tendency_of_y_wind">
-         <type kind="kind_phys" units="m s-2">real</type>
+         <type units="m s-2">real</type>
       </standard_name>
       <standard_name name="vertical_interface_dimension_interstitial">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_tbd_type">
       <standard_name name="absolute_momentum_flux_due_to_nonorographic_gwd"
                    description="Absolute momentum flux due to non-orographic gravity wave drag">
-         <type kind="kind_phys" units="various">real</type>
+         <type units="various">real</type>
       </standard_name>
       <standard_name name="cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls"
                    description="Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_aerosol_from_gocart_climatology">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="air_temperature_on_previous_timestep_in_xyz_dimensioned_restart_array">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="air_temperature_two_timesteps_back">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="atmosphere_boundary_layer_thickness">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="atmosphere_heat_diffusivity_from_shoc"
                    description="Atmospheric heat diffusivity from Simplified Higher-Order Closure stochastic physics scheme">
-         <type kind="kind_phys" units="m2 s-1">real</type>
+         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="atmosphere_updraft_convective_mass_flux_at_cloud_base_by_cloud_type">
-         <type kind="kind_phys" units="kg m-2 s-1">real</type>
+         <type units="kg m-2 s-1">real</type>
       </standard_name>
       <standard_name name="cloud_fraction_for_mg">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="counter_for_grell_freitas_convection">
-         <type kind="" units="count">integer</type>
+         <type units="count">integer</type>
       </standard_name>
       <standard_name name="convective_cloud_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="convective_cloud_condensate_mixing_ratio_wrt_moist_air"
                    description="Convective cloud condensate mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_graupel_particle">
-         <type kind="kind_phys" units="um">real</type>
+         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_ice_particle">
-         <type kind="kind_phys" units="um">real</type>
+         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_liquid_water_particle">
-         <type kind="kind_phys" units="um">real</type>
+         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_rain_particle">
-         <type kind="kind_phys" units="um">real</type>
+         <type units="um">real</type>
       </standard_name>
       <standard_name name="effective_radius_of_stratiform_cloud_snow_particle">
-         <type kind="kind_phys" units="um">real</type>
+         <type units="um">real</type>
       </standard_name>
       <standard_name name="stratospheric_water_vapor_forcing">
-         <type kind="kind_phys" units="various">real</type>
+         <type units="various">real</type>
       </standard_name>
       <standard_name name="heat_exchange_coefficient_for_myj_schemes"
                    description="Heat exchange coefficient for Mellor-Yamada-Janjic physics schemes">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="ice_nucleation_number_from_climatology">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="upward_virtual_potential_temperature_flux">
-         <type kind="kind_phys" units="K m s-1">real</type>
+         <type units="K m s-1">real</type>
       </standard_name>
       <standard_name name="upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_surface_layer_scheme"
                    description="Upward flux of specific humidity (water vapor mass mixing ratio with respect to moist air) at surface for MYJ surface layer scheme">
-         <type kind="kind_phys" units="m s-1 kg kg-1">real</type>
+         <type units="m s-1 kg kg-1">real</type>
       </standard_name>
       <standard_name name="cumulative_max_vertical_index_at_cloud_base_between_sw_radiation_calls"
                    description="Cumulative maximum vertical index at cloud base between shortwave radiation calls">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="map_of_block_column_number_to_global_i_index">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="map_of_block_column_number_to_global_j_index">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="turbulent_mixing_length">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_nonphysics"
                    description="Tendency of specific humidity (water vapor mass mixing ratio with respect to moist air) due to non-physics processes">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="momentum_exchange_coefficient_for_myj_schemes"
                    description="Momentum exchange coefficient for Mellor-Yamada-Janjic physics schemes">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="ozone_forcing">
-         <type kind="kind_phys" units="various">real</type>
+         <type units="various">real</type>
       </standard_name>
       <standard_name name="potential_temperature_of_air_at_top_of_viscous_sublayer">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="variance_of_water_vapor_mixing_ratio_wrt_moist_air"
                    description="Variance of specific humidity (water vapor mass mixing ratio with respect to moist air)">
-         <type kind="kind_phys" units="kg2 kg-2">real</type>
+         <type units="kg2 kg-2">real</type>
       </standard_name>
       <standard_name name="random_number">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="random_number_seed_for_mcica_longwave"
                    description="Random number seed for Monte-Carlo Independent Column Approximation longwave scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="random_number_seed_for_mcica_shortwave"
                    description="Random number seed for Monte-Carlo Independent Column Approximation shortwave scheme">
-         <type kind="" units="1">integer</type>
+         <type units="1">integer</type>
       </standard_name>
       <standard_name name="cumulative_min_vertical_index_at_cloud_base_between_sw_radiation_calls">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="stability_function_for_heat">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="subgrid_scale_cloud_area_fraction_in_atmosphere_layer">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="subgrid_scale_cloud_ice_mixing_ratio_wrt_moist_air"
                    description="Subgrid-scale cloud ice mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="subgrid_scale_cloud_liquid_water_mixing_ratio_wrt_moist_air"
                    description="Subgrid-scale cloud liquid water mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="subgrid_scale_cloud_fraction_from_shoc"
                    description="Subgrid-scale cloud fraction from Simplified Higher-Order Closure stochastic physics scheme">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="air_pressure_at_surface_on_previous_timestep">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="air_pressure_at_surface_two_timesteps_back">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="control_for_surface_layer_evaporation">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_for_myj_schemes"
                    description="Surface specific humidity (water vapor mass mixing ratio with respect to moist air) for Mellor-Yamada-Janjic physics schemes">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="enhancement_to_wind_speed_at_surface_adjacent_layer_due_to_convection">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="covariance_of_air_temperature_and_water_vapor_mixing_ratio_wrt_moist_air"
                    description="Covariance of air temperature and specific humidity (water vapor mass mixing ratio with respect to moist air)">
-         <type kind="kind_phys" units="K kg kg-1">real</type>
+         <type units="K kg kg-1">real</type>
       </standard_name>
       <standard_name name="variance_of_air_temperature">
-         <type kind="kind_phys" units="K2">real</type>
+         <type units="K2">real</type>
       </standard_name>
       <standard_name name="tendency_of_air_temperature_due_to_nonphysics">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_air_temperature_to_withhold_from_sppt"
                    description="Change of air temperature to withhold from stochastically perturbed physics tendencies per unit time">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_activated_cloud_condensation_nuclei_from_climatology"
                    description="Change of activated cloud condensation nuclei from climatology per unit time">
-         <type kind="kind_phys" units="kg-1 s-1">real</type>
+         <type units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_rain_on_dynamics_timestep_for_coupling"
                    description="Liquid water equivalent thickness of rain amount on dynamics timestep for coupling">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_snowfall_on_dynamics_timestep_for_coupling"
                    description="Liquid water equivalent thickness of snowfall amount on dynamics timestep for coupling">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="nonadvected_tke_multiplied_by_2"
                    description="Non-advected turbulent kinetic energy multiplied by 2">
-         <type kind="kind_phys" units="m2 s-2">real</type>
+         <type units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="x_wind_at_top_of_viscous_sublayer">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="y_wind_at_top_of_viscous_sublayer">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_on_previous_timestep_in_xyz_dimensioned_restart_array"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) on previous timestep in XYZ-dimensioned restart array">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_two_timesteps_back"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) two timesteps back">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="scaling_factor_for_momentum_at_top_of_viscous_sublayer">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="scaling_factor_for_potential_temperature_at_top_of_viscous_sublayer">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="scaling_factor_for_water_vapor_mixing_ratio_wrt_moist_air_at_top_of_viscous_sublayer"
                    description="Scaling factor for specific humidity (water vapor mass mixing ratio with respect to moist air) at the top of the viscous sublayer">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_sfcprop_type">
       <standard_name name="wet_canopy_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="baseline_surface_longwave_emissivity">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="baseline_roughness_length"
                    description="Baseline surface roughness length">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="air_temperature_in_canopy">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="air_vapor_pressure_in_canopy">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="canopy_intercepted_ice_mass">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="canopy_intercepted_liquid_water">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="canopy_water_mass_content">
-         <type kind="kind_phys" units="kg m-2">real</type>
+         <type units="kg m-2">real</type>
       </standard_name>
       <standard_name name="cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_ice"
                    description="Cloud condensed water mass mixing ratio with respect to moist air at surface over ice">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_land"
                    description="Cloud condensed water mass mixing ratio with respect to moist air at surface over land">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="coefficient_c_0">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="coefficient_c_d">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="coefficient_w_0">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="coefficient_w_d">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="convective_precipitation_rate_on_previous_timestep">
-         <type kind="kind_phys" units="mm s-1">real</type>
+         <type units="mm s-1">real</type>
       </standard_name>
       <standard_name name="deep_soil_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="frozen_precipitation_density">
-         <type kind="kind_phys" units="kg m-3">real</type>
+         <type units="kg m-3">real</type>
       </standard_name>
       <standard_name name="heat_content_in_diurnal_thermocline">
-         <type kind="kind_phys" units="K m">real</type>
+         <type units="K m">real</type>
       </standard_name>
       <standard_name name="diurnal_thermocline_layer_thickness">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="x_current_in_diurnal_thermocline">
-         <type kind="kind_phys" units="m2 s-1">real</type>
+         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="y_current_in_diurnal_thermocline">
-         <type kind="kind_phys" units="m2 s-1">real</type>
+         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="volumetric_equilibrium_soil_moisture">
-         <type kind="kind_phys" units="m3 m-3">real</type>
+         <type units="m3 m-3">real</type>
       </standard_name>
       <standard_name name="explicit_precipitation_rate_on_previous_timestep">
-         <type kind="kind_phys" units="mm s-1">real</type>
+         <type units="mm s-1">real</type>
       </standard_name>
       <standard_name name="fast_soil_pool_mass_content_of_carbon">
-         <type kind="kind_phys" units="g m-2">real</type>
+         <type units="g m-2">real</type>
       </standard_name>
       <standard_name name="fine_root_mass_content">
-         <type kind="kind_phys" units="g m-2">real</type>
+         <type units="g m-2">real</type>
       </standard_name>
       <standard_name name="control_for_frozen_soil_physics">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="precipitation_type">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="strong_cosz_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="weak_cosz_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="free_convection_layer_thickness_in_sea_water">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="consecutive_calls_for_grell_freitas_convection">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="graupel_precipitation_rate_on_previous_timestep">
-         <type kind="kind_phys" units="mm s-1">real</type>
+         <type units="mm s-1">real</type>
       </standard_name>
       <standard_name name="ground_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="ice_precipitation_rate_on_previous_timestep">
-         <type kind="kind_phys" units="mm s-1">real</type>
+         <type units="mm s-1">real</type>
       </standard_name>
       <standard_name name="control_for_diurnal_thermocline_calculation">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="temperature_in_ice_layer">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface">
                    description="Upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface">
-         <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
+         <type units="kg kg-1 m s-1">real</type>
       </standard_name>
       <standard_name name="upward_temperature_flux_at_surface">
-         <type kind="kind_phys" units="K m s-1">real</type>
+         <type units="K m s-1">real</type>
       </standard_name>
       <standard_name name="lake_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="lake_depth">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="water_storage_in_lake">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="land_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="depth_from_snow_surface_at_bottom_interface">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="leaf_area_index">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="leaf_mass_content">
-         <type kind="kind_phys" units="g m-2">real</type>
+         <type units="g m-2">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_convective_precipitation_on_previous_timestep"
                    description="Liquid water equivalent thickness of convective precipitation amount on previous timestep">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_explicit_precipitation_on_previous_timestep"
                    description="Liquid water equivalent thickness of explicit precipitation amount on previous timestep">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_graupel_on_previous_timestep"
                    description="Liquid water equivalent thickness of graupel amount on previous timestep">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_ice_precipitation_on_previous_timestep"
                    description="Liquid water equivalent thickness of ice precipitation amount on previous timestep">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="snow_mass_on_previous_timestep">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="max_vegetation_area_fraction"
                    description="Maximum vegetation area fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="nir_albedo_strong_cosz"
                      description="albedo for near-infrared radiation with strong dependence on cosine of the zenith angle">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="nir_albedo_weak_cosz">
                      description="albedo for near-infrared radiation with weak dependence on cosine of the zenith angle">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="vis_albedo_strong_cosz">
                      description="albedo for visible radiation with strong dependence on cosine of the zenith angle">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="vis_albedo_weak_cosz">
                      description="albedo for visible radiation with weak dependence on cosine of the zenith angle">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="min_vegetation_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="monin_obukhov_similarity_function_for_heat">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="monin_obukhov_similarity_function_for_momentum">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="dimensionless_age_of_surface_snow">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="nonnegative_lwe_thickness_of_precipitation_on_dynamics_timestep"
                    description="Non-negative liquid water equivalent thickness of precipitation amount on dynamics timestep">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="normalized_soil_wetness_for_lsm"
                    description="Normalized soil wetness for land surface model">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="number_of_snow_layers">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="ocean_mixed_layer_thickness">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="height_above_mean_sea_level">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="height_above_mean_sea_level_at_surface"
                      description="Height above mean sea level at local surface">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="unfiltered_height_above_mean_sea_level">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="potential_temperature_of_air_at_2m">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="ratio_of_wind_at_surface_adjacent_layer_to_wind_at_10m">
-         <type kind="kind_phys" units="ratio">real</type>
+         <type units="ratio">real</type>
       </standard_name>
       <standard_name name="reciprocal_of_obukhov_length">
-         <type kind="kind_phys" units="m-1">real</type>
+         <type units="m-1">real</type>
       </standard_name>
       <standard_name name="sea_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="sea_ice_area_fraction_of_sea_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="sea_ice_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="sea_ice_thickness">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="area_type">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="reference_sea_surface_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="sea_surface_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="sea_water_salinity_in_diurnal_thermocline">
-         <type kind="kind_phys" units="ppt m">real</type>
+         <type units="ppt m">real</type>
       </standard_name>
       <standard_name name="surface_sensible_heat_due_to_rainfall">
-         <type kind="kind_phys" units="W">real</type>
+         <type units="W">real</type>
       </standard_name>
       <standard_name name="derivative_of_heat_content_in_diurnal_thermocline_wrt_surface_skin_temperature">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="derivative_of_diurnal_thermocline_layer_thickness_wrt_surface_skin_temperature">
-         <type kind="kind_phys" units="m K-1">real</type>
+         <type units="m K-1">real</type>
       </standard_name>
       <standard_name name="slow_soil_pool_mass_content_of_carbon">
-         <type kind="kind_phys" units="g m-2">real</type>
+         <type units="g m-2">real</type>
       </standard_name>
       <standard_name name="albedo_on_previous_timestep_assuming_deep_snow">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_ice_in_surface_snow"
                    description="Liquid water equivalent thickness of ice in surface snow">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_liquid_water_in_surface_snow"
                    description="Liquid water equivalent thickness of liquid water in surface snow">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_snowfall_on_previous_timestep"
                    description="Liquid water equivalent thickness of snowfall amount on previous timestep">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="lwe_snowfall_rate"
                    description="Liquid water equivalent snowfall rate">
-         <type kind="kind_phys" units="mm s-1">real</type>
+         <type units="mm s-1">real</type>
       </standard_name>
       <standard_name name="snowfall_rate_on_previous_timestep">
-         <type kind="kind_phys" units="mm s-1">real</type>
+         <type units="mm s-1">real</type>
       </standard_name>
       <standard_name name="temperature_in_surface_snow">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="temperature_in_surface_snow_at_surface_adjacent_layer_over_ice">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="temperature_in_surface_snow_at_surface_adjacent_layer_over_land">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="soil_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="soil_temperature_for_lsm"
                    description="Soil temperature for land surface model">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="volumetric_soil_moisture_between_soil_bottom_and_water_table">
-         <type kind="kind_phys" units="m3 m-3">real</type>
+         <type units="m3 m-3">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_2m"
                      description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at two meters above surface">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m"
                      description="mixing ratio of the mass of water vapor to the mass of moist air and hydrometeors, at two meters above surface">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface"
                    description="Specified upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface">
-         <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
+         <type units="kg kg-1 m s-1">real</type>
       </standard_name>
       <standard_name name="specified_upward_temperature_flux_at_surface">
-         <type kind="kind_phys" units="K m s-1">real</type>
+         <type units="K m s-1">real</type>
       </standard_name>
       <standard_name name="standard_deviation_of_subgrid_orography">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="statistical_measures_of_subgrid_orography_collection_array">
-         <type kind="kind_phys" units="various">real</type>
+         <type units="various">real</type>
       </standard_name>
       <standard_name name="stem_area_index">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="stem_mass_content">
-         <type kind="kind_phys" units="g m-2">real</type>
+         <type units="g m-2">real</type>
       </standard_name>
       <standard_name name="molecular_sublayer_temperature_correction_in_sea_water">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="molecular_sublayer_thickness_in_sea_water">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="diffuse_nir_albedo_of_ice"
                      description="ice surface albedo for diffuse near-infrared radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="diffuse_nir_albedo_of_land"
                      description="land surface albedo for diffuse near-infrared radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="diffuse_vis_albedo_of_ice"
                      description="ice surface albedo for diffuse visible radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="diffuse_vis_albedo_of_land"
                      description="land surface albedo for diffuse visible radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="direct_nir_albedo_of_ice"
                      description="ice surface albedo for direct near-infrared radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="direct_nir_albedo_of_land"
                      description="land surface albedo for direct near-infrared radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="direct_vis_albedo_of_ice"
                      description="ice surface albedo for direct visible radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="direct_vis_albedo_of_land"
                      description="land surface albedo for direct visible radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="diffuse_shortwave_albedo_of_ice"
                      description="ice surface albedo for diffuse shortwave radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="diffuse_shortwave_albedo_of_land"
                      description="land surface albedo for diffuse shortwave radiation">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="surface_drag_coefficient_for_heat_and_moisture_for_noahmp"
                    description="Surface drag coefficient for heat and moisture for Noah land surface model with multiparameterization options">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="surface_drag_coefficient_for_momentum_for_noahmp"
                    description="Surface drag coefficient for momentum for Noah land surface model with multiparameterization options">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="surface_exchange_coefficient_for_heat">
-         <type kind="kind_phys" units="W m-2 K-1">real</type>
+         <type units="W m-2 K-1">real</type>
       </standard_name>
       <standard_name name="surface_exchange_coefficient_for_heat_at_2m">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="surface_exchange_coefficient_for_moisture">
-         <type kind="kind_phys" units="kg m-2 s-1">real</type>
+         <type units="kg m-2 s-1">real</type>
       </standard_name>
       <standard_name name="surface_exchange_coefficient_for_moisture_at_2m">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="surface_friction_velocity">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="surface_friction_velocity_for_momentum">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="upward_latent_heat_flux_at_surface">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="surface_longwave_emissivity_over_ice">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="surface_longwave_emissivity_over_land">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="roughness_length"
                    description="surface roughness length">
-         <type kind="kind_phys" units="cm">real</type>
+         <type units="cm">real</type>
       </standard_name>
       <standard_name name="roughness_length_from_wave_model"
                    description="surface roughness length from wave model">
-         <type kind="kind_phys" units="cm">real</type>
+         <type units="cm">real</type>
       </standard_name>
       <standard_name name="roughness_length_over_ice"
                    description="surface roughness length over ice">
-         <type kind="kind_phys" units="cm">real</type>
+         <type units="cm">real</type>
       </standard_name>
       <standard_name name="roughness_length_over_land"
                    description="surface roughness length over land">
-         <type kind="kind_phys" units="cm">real</type>
+         <type units="cm">real</type>
       </standard_name>
       <standard_name name="roughness_length_over_water"
                    description="surface roughness length over water">
-         <type kind="kind_phys" units="cm">real</type>
+         <type units="cm">real</type>
       </standard_name>
       <standard_name name="skin_temperature_at_surface"
                      description="Skin temperature at surface">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="skin_temperature_at_surface_over_ice"
                      description="Skin temperature at surface over (or where) ice">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="skin_temperature_at_surface_over_land"
                      description="Skin temperature at surface over (or where) land">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="skin_temperature_at_surface_over_ocean"
                      description="Skin temperature at surface over (or where) ocean">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="skin_temperature_at_surface_over_snow"
                      description="Skin temperature at surface over (or where) snow">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="snow_area_fraction_at_surface_over_ice">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="snow_area_fraction_at_surface_over_land">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="albedo_of_land_assuming_no_snow_cover"
                    description="surface snow-free albedo over land">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="lwe_surface_snow"
                    description="Liquid water equivalent surface snow">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="ratio_of_height_to_monin_obukhov_length">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="air_temperature_at_2m">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="surface_temperature_scale">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="time_since_last_snowfall">
-         <type kind="kind_phys" units="s">real</type>
+         <type units="s">real</type>
       </standard_name>
       <standard_name name="surface_snow_mass_content_over_ice">
-         <type kind="kind_phys" units="kg m-2">real</type>
+         <type units="kg m-2">real</type>
       </standard_name>
       <standard_name name="surface_snow_mass_content_over_land">
-         <type kind="kind_phys" units="kg m-2">real</type>
+         <type units="kg m-2">real</type>
       </standard_name>
       <standard_name name="upper_bound_of_max_albedo_assuming_deep_snow"
                    description="Upper bound of maximum albedo assuming deep snow">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="vegetation_area_fraction">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="canopy_temperature">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="volume_fraction_of_frozen_soil_moisture_for_lsm"
                    description="Volume fraction of frozen soil moisture for land surface model">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="volume_fraction_of_condensed_water_in_soil">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="volume_fraction_of_soil_moisture_for_lsm"
                    description="Volume fraction of soil moisture for land surface model">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="volume_fraction_of_unfrozen_water_in_soil">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="volume_fraction_of_unfrozen_soil_moisture_for_lsm"
                    description="Volume fraction of unfrozen soil moisture for land surface model">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="lwe_thickness_of_surface_snow"
                    description="Liquid water equivalent thickness of surface snow amount">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="water_storage_in_aquifer">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="water_storage_in_aquifer_and_saturated_soil">
-         <type kind="kind_phys" units="mm">real</type>
+         <type units="mm">real</type>
       </standard_name>
       <standard_name name="water_table_depth">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="water_table_recharge_assuming_deep">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="water_table_recharge_assuming_shallow">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_ice"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over ice">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_over_land"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface over land">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="wood_mass_content">
-         <type kind="kind_phys" units="g m-2">real</type>
+         <type units="g m-2">real</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_coupling_type">
       <standard_name name="cellular_automata_global_pattern_from_coupled_process">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="convective_cloud_condensate_after_rainout">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="cumulative_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative net downwelling diffuse near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative net downwelling direct near-infrared shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep"
                      description="cumulative net downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling multiplied by the duration of the timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_net_downwelling_longwave_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_net_downwelling_shortwave_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_upward_latent_heat_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_upward_sensible_heat_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="J m-2">real</type>
+         <type units="J m-2">real</type>
       </standard_name>
       <standard_name name="cumulative_x_momentum_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="Pa s">real</type>
+         <type units="Pa s">real</type>
       </standard_name>
       <standard_name name="cumulative_y_momentum_flux_at_surface_for_coupling_multiplied_by_timestep">
-         <type kind="kind_phys" units="Pa s">real</type>
+         <type units="Pa s">real</type>
       </standard_name>
       <standard_name name="cellular_automata_area_fraction_for_deep_convection_from_coupled_process">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="atmosphere_heat_diffusivity_for_chemistry_coupling">
-         <type kind="kind_phys" units="m2 s-1">real</type>
+         <type units="m2 s-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_2m_for_coupling"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at 2 meters above surface used for coupling">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="air_pressure_at_surface_for_coupling">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling"
                      description="downwelling diffuse near-infrared shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling"
                      description="downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_for_coupling"
                      description="downwelling direct near-infrared shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling"
                      description="downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_longwave_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_shortwave_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_diffuse_nir_shortwave_flux_at_surface_for_coupling"
                      description="net downwelling diffuse near-infrared shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_for_coupling"
                      description="net downwelling diffuse ultraviolet and visible shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_direct_nir_shortwave_flux_at_surface_for_coupling"
                      description="net downwelling direct near-infrared shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_direct_uv_and_vis_shortwave_flux_at_surface_for_coupling"
                      description="net_downwelling direct ultraviolet and visible shortwave flux at the surface level for coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_longwave_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_shortwave_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="surface_skin_temperature_for_coupling">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="upward_latent_heat_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upward_sensible_heat_flux_at_surface_for_chemistry_coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upward_sensible_heat_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="x_momentum_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="y_momentum_flux_at_surface_for_coupling">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="temperature_at_2m_for_coupling">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="tendency_of_water_vapor_mixing_ratio_wrt_moist_air_due_to_moist_convection_for_coupling">
                    description="Tendency of specific humidity (water vapor mass mixing ratio with respect to moist air) due to moist convection used for coupling">
-         <type kind="kind_phys" units="kg kg-1 s-1">real</type>
+         <type units="kg kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="x_wind_at_10m_for_coupling">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="y_wind_at_10m_for_coupling">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="cumulative_lwe_thickness_of_convective_precipitation_for_coupling"
                    description="Cumulative liquid water equivalent thickness of convective precipitation amount for coupling">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="cumulative_lwe_thickness_of_precipitation_for_coupling"
                    description="Cumulative liquid water equivalent thickness of precipitation amount for coupling">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="cumulative_lwe_thickness_of_snow_for_coupling"
                    description="Cumulative liquid water equivalent thickness of snow amount for coupling">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="physics_field_for_coupling">
-         <type kind="kind_phys" units="m2 s-2">real</type>
+         <type units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="rrtmgp_jacobian_of_upward_lw_flux"
                    description="Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) jacobian of upward longwave flux">
-         <type kind="kind_phys" units="W m-2 K-1">real</type>
+         <type units="W m-2 K-1">real</type>
       </standard_name>
       <standard_name name="rrtmgp_lw_downward_allsky_flux_profile"
                    description="Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave downward all-sky flux profile">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="rrtmgp_lw_upward_allsky_flux_profile"
                    description="Rapid Radiative Transfer Model for General circulation model applications - Parallel (RRTMGP) longwave upward all-sky flux profile">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="area_type_from_coupled_process">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="downwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep"
                      description="downwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
                      description="downwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep"
                      description="downwelling direct near-infrared shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
                      description="downwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_longwave_flux_at_surface_on_radiation_timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="downwelling_shortwave_flux_at_surface_on_radiation_timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="net_downwelling_shortwave_flux_at_surface_on_radiation_timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="diffuse_nir_albedo_for_coupling"
                      description="surface albedo for diffuse near-infrared radiation for coupling">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="direct_nir_albedo_for_coupling"
                      description="surface albedo for direct near-infrared radiation for coupling">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="lwe_surface_snow_from_coupled_process"
                    description="Liquid water equivalent surface snow from coupled process">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="upward_latent_heat_flux_at_surface_from_coupled_process">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upward_sensible_heat_flux_at_surface_from_coupled_process">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upwelling_diffuse_nir_shortwave_flux_at_surface_on_radiation_timestep"
                      description="upwelling diffuse near-infrared shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upwelling_diffuse_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
                      description="upwelling diffuse ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upwelling_direct_nir_shortwave_flux_at_surface_on_radiation_timestep"
                      description="upwelling direct near-infrared shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upwelling_direct_uv_and_vis_shortwave_flux_at_surface_on_radiation_timestep"
                      description="upwelling direct ultraviolet and visible shortwave flux at the surface level on the radiation timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upwelling_longwave_flux_at_surface_from_coupled_process">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="upwelling_longwave_flux_at_surface_on_radiation_timestep">
-         <type kind="kind_phys" units="W m-2">real</type>
+         <type units="W m-2">real</type>
       </standard_name>
       <standard_name name="diffuse_vis_albedo_for_coupling"
                      description="surface albedo for diffuse visible radiation for coupling">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="direct_vis_albedo_for_coupling"
                      description="surface albedo for direct visible radiation for coupling">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="x_momentum_flux_at_surface_from_coupled_process">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="y_momentum_flux_at_surface_from_coupled_process">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="tendency_of_nonhygroscopic_ice_nucleating_aerosols_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="kg-1 s-1">real</type>
+         <type units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_hygroscopic_aerosols_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="kg-1 s-1">real</type>
+         <type units="kg-1 s-1">real</type>
       </standard_name>
       <standard_name name="updated_tendency_of_air_temperature_due_to_longwave_heating_on_physics_timestep">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="cellular_automata_vertical_scaling_factor">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="shum_scaling_factors_from_coupled_process"
                    description="Stochastic Humidity stochastic physics option scaling factors from coupled process">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="skeb_x_wind_scaling_factors_from_coupled_process"
                    description="Stochastic Kinetic Energy Backscatter x-wind scaling factors from coupled process">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="skeb_y_wind_scaling_factors_from_coupled_process"
                    description="Stochastic Kinetic Energy Backscatter y-wind scaling factors from coupled process">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="sppt_scaling_factors_from_coupled_process"
                    description="Stochastically perturbed physics tendencies scaling factors from coupled process">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="surface_stochastic_scaling_factors_from_coupled_process">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_statein_type">
       <standard_name name="air_pressure_at_lowest_model_interface">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="air_pressure_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="air_temperature_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer"
                    description="Cloud liquid water mass mixing ratio with respect to moist air at surface-adjacent layer">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="exner_function_wrt_surface_pressure"
                    description="Exner function with respect to surface pressure, (p/ps)^(Rd/cp)">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="exner_function_at_surface_adjacent_layer"
                    description="exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at the surface-adjacent layer">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="exner_function_at_interfaces"
                    description="exner function (p/p0)^(Rd/cp), where p0 is 1000 hPa and p is the pressure at vertical layer interfaces">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="dissipation_estimate_of_air_temperature_at_model_layers">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="geopotential">
-         <type kind="kind_phys" units="m2 s-2">real</type>
+         <type units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="geopotential_at_interfaces">
-         <type kind="kind_phys" units="m2 s-2">real</type>
+         <type units="m2 s-2">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air"
                    description="Graupel mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_graupel_in_air">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_cloud_ice_water_crystals_in_air">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="ozone_mixing_ratio_wrt_moist_air"
                    description="Ozone mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_rain_in_air">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_snow_in_air">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="snow_mixing_ratio_wrt_moist_air"
                    description="Snow mass mixing ratio with respect to moist air">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="tracer_concentration">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_hygroscopic_aerosols">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_surface_adjacent_layer"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at surface-adjacent layer">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="x_wind_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="y_wind_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_cldprop_type">
       <standard_name name="convective_cloud_area_fraction_between_sw_radiation_calls_from_cnvc90"
                    description="Convective cloud area fraction between shortwave radiation calls from GFS Convective Cloud Diagnostics">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="pressure_at_convective_cloud_base_between_sw_radiation_calls_from_cnvc90"
                    description="Pressure at convective cloud base between shortwave radiation calls from GFS Convective Cloud Diagnostics">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="pressure_at_convective_cloud_top_between_sw_radiation_calls_from_cnvc90"
                    description="Pressure at convective cloud top between shortwave radiation calls from GFS Convective Cloud Diagnostics">
-         <type kind="kind_phys" units="Pa">real</type>
+         <type units="Pa">real</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_radtend_type">
       <standard_name name="cosine_of_solar_zenith_angle_for_daytime_points_on_radiation_timestep">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="cosine_of_solar_zenith_angle_on_radiation_timestep">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="surface_lw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep">
-         <type kind="" units="W m-2">sfcflw_type</type>
+         <type units="W m-2">sfcflw_type</type>
       </standard_name>
       <standard_name name="diffuse_shortwave_albedo_on_radiation_timestep"
                      description="surface albedo for diffuse shortwave radiation on the timestep for radiation physics">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="surface_longwave_emissivity">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="air_temperature_at_surface_adjacent_layer_on_radiation_timestep">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="surface_sw_fluxes_assuming_total_and_clear_sky_on_radiation_timestep">
-         <type kind="" units="W m-2">sfcfsw_type</type>
+         <type units="W m-2">sfcfsw_type</type>
       </standard_name>
       <standard_name name="tendency_of_air_temperature_due_to_longwave_heating_assuming_clear_sky_on_radiation_timestep">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_air_temperature_due_to_integrated_dynamics_through_earths_atmosphere">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_air_temperature_due_to_longwave_heating_on_radiation_timestep">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_air_temperature_due_to_shortwave_heating_assuming_clear_sky_on_radiation_timestep">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
       <standard_name name="tendency_of_air_temperature_due_to_shortwave_heating_on_radiation_timestep">
-         <type kind="kind_phys" units="K s-1">real</type>
+         <type units="K s-1">real</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_grid_type">
       <standard_name name="longitude_interpolation_scaling_factor_for_aerosol_forcing">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="latitude_interpolation_scaling_factor_for_aerosol_forcing">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="characteristic_grid_lengthscale">
-         <type kind="kind_phys" units="m">real</type>
+         <type units="m">real</type>
       </standard_name>
       <standard_name name="longitude_interpolation_scaling_factor_for_cloud_nuclei_forcing">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="latitude_interpolation_scaling_factor_for_cloud_nuclei_forcing">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="cosine_of_latitude">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="latitude_interpolation_scaling_factor_complement_for_absolute_momentum_flux_due_to_nonorographic_gwd"
                    description="Latitude interpolation scaling factor complement for absolute momentum flux due to non-orographic gravity wave drag">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="latitude_interpolation_scaling_factor_for_absolute_momentum_flux_due_to_nonorographic_gwd"
                    description="Latitude interpolation scaling factor for absolute momentum flux due to non-orographic gravity wave drag">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="lower_longitude_index_of_aerosol_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="lower_latitude_index_of_aerosol_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="lower_longitude_index_of_cloud_nuclei_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="lower_latitude_index_of_cloud_nuclei_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="lower_latitude_index_of_absolute_momentum_flux_due_to_nonorographic_gwd_for_interpolation"
                    description="Lower latitude index of absolute momentum flux due to non-orographic gravity wave drag for interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="lower_latitude_index_of_ozone_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="lower_latitude_index_of_stratospheric_water_vapor_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="latitude_interpolation_scaling_factor_for_ozone_forcing">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="sine_of_latitude">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
       <standard_name name="upper_longitude_index_of_aerosol_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="upper_latitude_index_of_aerosol_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="upper_longitude_index_of_cloud_nuclei_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="upper_latitude_index_of_cloud_nuclei_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="upper_latitude_index_of_absolute_momentum_flux_due_to_nonorographic_gwd_for_interpolation"
                    description="Upper latitude index of absolute momentum flux due to non-orographic gravity wave drag for interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="upper_latitude_index_of_ozone_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="upper_latitude_index_of_stratospheric_water_vapor_forcing_for_interpolation">
-         <type kind="" units="index">integer</type>
+         <type units="index">integer</type>
       </standard_name>
       <standard_name name="latitude_interpolation_scaling_factor_for_stratospheric_water_vapor_forcing">
-         <type kind="kind_phys" units="1">real</type>
+         <type units="1">real</type>
       </standard_name>
    </section>
    <section name="GFS_typedefs_GFS_stateout_type">
       <standard_name name="air_temperature_of_new_state_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="air_temperature_of_new_state">
-         <type kind="kind_phys" units="K">real</type>
+         <type units="K">real</type>
       </standard_name>
       <standard_name name="cloud_liquid_water_mixing_ratio_wrt_moist_air_of_new_state"
                    description="Cloud liquid water mass mixing ratio with respect to moist air of new state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_cloud_liquid_water_particles_in_air_of_new_state">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="nonconvective_cloud_area_fraction_in_atmosphere_layer_of_new_state">
-         <type kind="kind_phys" units="fraction">real</type>
+         <type units="fraction">real</type>
       </standard_name>
       <standard_name name="graupel_mixing_ratio_wrt_moist_air_of_new_state"
                    description="Graupel mass mixing ratio with respect to moist air of new state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_graupel_of_new_state">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_nonhygroscopic_ice_nucleating_aerosols_of_new_state">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_cloud_ice_water_crystals_in_air_of_new_state">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="cloud_ice_mixing_ratio_wrt_moist_air_of_new_state"
                    description="Cloud ice mass mixing ratio with respect to moist air of new state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_weighted_rime_factor_of_new_state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="ozone_concentration_of_new_state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_rain_of_new_state">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="rain_mixing_ratio_wrt_moist_air_of_new_state"
                    description="Rain mass mixing ratio with respect to moist air of new state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_snow_of_new_state">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="snow_mixing_ratio_wrt_moist_air_of_new_state"
                    description="Snow mass mixing ratio with respect to moist air of new state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="tracer_concentration_of_new_state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="mass_number_concentration_of_hygroscopic_aerosols_of_new_state">
-         <type kind="kind_phys" units="kg-1">real</type>
+         <type units="kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_of_new_state_at_surface_adjacent_layer"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state at surface-adjacent layer">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_of_new_state"
                    description="Specific humidity (water vapor mass mixing ratio with respect to moist air) of new state">
-         <type kind="kind_phys" units="kg kg-1">real</type>
+         <type units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="x_wind_of_new_state_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="x_wind_of_new_state">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="y_wind_of_new_state_at_surface_adjacent_layer">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
       <standard_name name="y_wind_of_new_state">
-         <type kind="kind_phys" units="m s-1">real</type>
+         <type units="m s-1">real</type>
       </standard_name>
    </section>
 </standard_names>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -322,8 +322,8 @@
       <standard_name name="divergence">
         <type units="s-1">real</type>
       </standard_name>
-      <standard_name name="dry_air_density"
-                     description="Density of air excluding water vapor component">
+      <standard_name name="dry_air"
+                     description="Air excluding all water components">
         <type units="kg m-3">real</type>
       </standard_name>
       <standard_name name="dry_air_enthalpy_at_constant_pressure"
@@ -561,7 +561,8 @@
       <type units="count">integer</type>
     </standard_name>
   </section>
-  <section name="constants">
+  <section name="constants"
+           comment="Constant parameters that should be identical across a full modeling system">
     <standard_name name="avogadro_number">
       <type kind="kind_phys" units="molecules mol-1">real</type>
     </standard_name>
@@ -571,24 +572,7 @@
     <standard_name name="boltzmann_constant">
       <type kind="kind_phys" units="J K-1">real</type>
     </standard_name>
-    <standard_name name="gas_constant_of_dry_air">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
-    </standard_name>
-    <standard_name name="seconds_in_calendar_day">
-      <type kind="kind_phys" units="s">integer</type>
-    </standard_name>
-    <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
-    </standard_name>
-    <standard_name name="specific_heat_of_liquid_water_at_20c"
-              description="Specific heat of liquid water at 20 degrees Celsius">
-      <type kind="kind_phys" units="J kg-1 K-1">real</type>
-    </standard_name>
-    <standard_name name="latent_heat_of_vaporization_of_water_at_0c"
-                   description="Latent heat of vaporization of water at 0 degrees Celsius">
-      <type kind="kind_phys" units="J kg-1">real</type>
-    </standard_name>
-    <standard_name name="dry_air_density_at_stp"
+    <standard_name name="density_of_dry_air_at_stp"
               description="Density of dry air at standard temperature and pressure">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
@@ -596,10 +580,24 @@
                    description="Density of liquid water at 0 degrees Celsius">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
+    <standard_name name="gas_constant_of_dry_air">
+      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
+    <standard_name name="latent_heat_of_vaporization_of_water_at_0c"
+                   description="Latent heat of vaporization of water at 0 degrees Celsius">
+      <type kind="kind_phys" units="J kg-1">real</type>
+    </standard_name>
     <standard_name
         name="ratio_of_water_vapor_to_dry_air_gas_constants_minus_one"
         description="Ratio of gas constants of water vapor and dry air minus one; (Rwv / Rdair) - 1.0">
       <type kind="kind_phys" units="1">real</type>
+    </standard_name>
+    <standard_name name="seconds_in_calendar_day">
+      <type kind="kind_phys" units="s">integer</type>
+    </standard_name>
+    <standard_name name="specific_heat_of_liquid_water_at_20c"
+              description="Specific heat of liquid water at 20 degrees Celsius">
+      <type kind="kind_phys" units="J kg-1 K-1">real</type>
     </standard_name>
     <standard_name
         name="standard_gravitational_acceleration"
@@ -623,6 +621,9 @@
   </section>
   <section name="state_variables"
            comment="Note that appending '_on_previous_timestep' to standard_names in this section yields another valid standard_name">
+    <standard_name name="specific_heat_of_dry_air_at_constant_pressure">
+      <type kind="kind_phys" units="J kg-1 K-1">real</type>
+    </standard_name>
     <standard_name name="physics_state_due_to_dynamics">
       <type kind="kind_phys" units="none">physics_state</type>
     </standard_name>
@@ -698,7 +699,7 @@
                    description="Dry static energy content of atmosphere layer">
       <type kind="kind_phys" units="J kg-1">real</type>
     </standard_name>
-    <standard_name name="do_lagrangian_vertical_coordinate"
+    <standard_name name="flag_for_lagrangian_vertical_coordinate"
                    description="Flag indicating if vertical coordinate is lagrangian">
       <type kind="" units="flag">logical</type>
     </standard_name>
@@ -706,7 +707,7 @@
                    description="Vertical pressure velocity">
       <type kind="kind_phys" units="Pa s-1">real</type>
     </standard_name>
-    <standard_name name="dry_air_density"
+    <standard_name name="density_of_dry_air"
                    description="Density of dry air">
       <type kind="kind_phys" units="kg m-3">real</type>
     </standard_name>
@@ -1424,7 +1425,7 @@
       <standard_name name="ccpp_thread_number"
                      description="Number of current OpenMP thread. This variable may only be used during CCPP run phase">
         <type units="index">integer</type>
-      </standard_name> 
+      </standard_name>
     </section>
   </section>
   <section name="system variables"
@@ -3477,7 +3478,7 @@ GFS near-surface sea temperature scheme
          <type kind="kind_phys" units="m3 m-3">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_at_2m"
-                     description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at two meters above surface"> 
+                     description="Specific humidity (water vapor mass mixing ratio with respect to moist air) at two meters above surface">
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="water_vapor_mixing_ratio_wrt_moist_air_and_condensed_water_at_2m"
@@ -3485,7 +3486,7 @@ GFS near-surface sea temperature scheme
          <type kind="kind_phys" units="kg kg-1">real</type>
       </standard_name>
       <standard_name name="specified_upward_flux_of_water_vapor_mixing_ratio_wrt_moist_air_at_surface"
-                   description="Specified upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface"> 
+                   description="Specified upward specific humidity (water vapor mass mixing ratio with respect to moist air) flux at surface">
          <type kind="kind_phys" units="kg kg-1 m s-1">real</type>
       </standard_name>
       <standard_name name="specified_upward_temperature_flux_at_surface">

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -7,9 +7,6 @@
              comment="The following names are too general to be chosen as\n
                       standard names, but they can serve as base names for\n
                       more specific standard names.\n">
-      <standard_name name="amount">
-        <type units="kg m-2">real</type>
-      </standard_name>
       <standard_name name="area">
         <type units="m2">real</type>
       </standard_name>
@@ -57,6 +54,10 @@
       </standard_name>
       <standard_name name="mass">
         <type units="kg">real</type>
+      </standard_name>
+      <standard_name name="mass_content"
+                     description="Integrated mass over a given area and vertical extent">
+        <type units="kg m-2">real</type>
       </standard_name>
       <standard_name name="mass_flux"
                      description="Mass traveling through an area per unit time">
@@ -254,7 +255,8 @@
                      description="The pressure of air">
         <type units="Pa">real</type>
       </standard_name>
-      <standard_name name="air_pressure_thickness">
+      <standard_name name="air_pressure_thickness"
+                     description="The difference in air pressure between two vertical layers">
         <type units="Pa">real</type>
       </standard_name>
       <standard_name name="air_temperature"
@@ -2963,7 +2965,7 @@ GFS near-surface sea temperature scheme
                    description="Absolute momentum flux due to non-orographic gravity wave drag">
          <type kind="kind_phys" units="various">real</type>
       </standard_name>
-      <standard_name name="cumulative_lwe_thickness_of_convective_precipitation_amount_between_sw_radiation_calls"
+      <standard_name name="cumulative_lwe_thickness_of_convective_precipitation_between_sw_radiation_calls"
                    description="Cumulative liquid water equivalent thickness of convective precipitation amount between shortwave radiation calls">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
@@ -3136,11 +3138,11 @@ GFS near-surface sea temperature scheme
                    description="Change of activated cloud condensation nuclei from climatology per unit time">
          <type kind="kind_phys" units="kg-1 s-1">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_rain_amount_on_dynamics_timestep_for_coupling"
+      <standard_name name="lwe_thickness_of_rain_on_dynamics_timestep_for_coupling"
                    description="Liquid water equivalent thickness of rain amount on dynamics timestep for coupling">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_snowfall_amount_on_dynamics_timestep_for_coupling"
+      <standard_name name="lwe_thickness_of_snowfall_on_dynamics_timestep_for_coupling"
                    description="Liquid water equivalent thickness of snowfall amount on dynamics timestep for coupling">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
@@ -3196,7 +3198,7 @@ GFS near-surface sea temperature scheme
       <standard_name name="canopy_intercepted_liquid_water">
          <type kind="kind_phys" units="mm">real</type>
       </standard_name>
-      <standard_name name="canopy_water_amount">
+      <standard_name name="canopy_water_mass_content">
          <type kind="kind_phys" units="kg m-2">real</type>
       </standard_name>
       <standard_name name="cloud_condensed_water_mixing_ratio_wrt_moist_air_at_surface_over_ice"
@@ -3313,19 +3315,19 @@ GFS near-surface sea temperature scheme
       <standard_name name="leaf_mass_content">
          <type kind="kind_phys" units="g m-2">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_convective_precipitation_amount_on_previous_timestep"
+      <standard_name name="lwe_thickness_of_convective_precipitation_on_previous_timestep"
                    description="Liquid water equivalent thickness of convective precipitation amount on previous timestep">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_explicit_precipitation_amount_on_previous_timestep"
+      <standard_name name="lwe_thickness_of_explicit_precipitation_on_previous_timestep"
                    description="Liquid water equivalent thickness of explicit precipitation amount on previous timestep">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_graupel_amount_on_previous_timestep"
+      <standard_name name="lwe_thickness_of_graupel_on_previous_timestep"
                    description="Liquid water equivalent thickness of graupel amount on previous timestep">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_ice_precipitation_amount_on_previous_timestep"
+      <standard_name name="lwe_thickness_of_ice_precipitation_on_previous_timestep"
                    description="Liquid water equivalent thickness of ice precipitation amount on previous timestep">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
@@ -3364,7 +3366,7 @@ GFS near-surface sea temperature scheme
       <standard_name name="dimensionless_age_of_surface_snow">
          <type kind="kind_phys" units="1">real</type>
       </standard_name>
-      <standard_name name="nonnegative_lwe_thickness_of_precipitation_amount_on_dynamics_timestep"
+      <standard_name name="nonnegative_lwe_thickness_of_precipitation_on_dynamics_timestep"
                    description="Non-negative liquid water equivalent thickness of precipitation amount on dynamics timestep">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
@@ -3444,7 +3446,7 @@ GFS near-surface sea temperature scheme
                    description="Liquid water equivalent thickness of liquid water in surface snow">
          <type kind="kind_phys" units="mm">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_snowfall_amount_on_previous_timestep"
+      <standard_name name="lwe_thickness_of_snowfall_on_previous_timestep"
                    description="Liquid water equivalent thickness of snowfall amount on previous timestep">
          <type kind="kind_phys" units="mm">real</type>
       </standard_name>
@@ -3652,10 +3654,10 @@ GFS near-surface sea temperature scheme
       <standard_name name="time_since_last_snowfall">
          <type kind="kind_phys" units="s">real</type>
       </standard_name>
-      <standard_name name="surface_snow_amount_over_ice">
+      <standard_name name="surface_snow_mass_content_over_ice">
          <type kind="kind_phys" units="kg m-2">real</type>
       </standard_name>
-      <standard_name name="surface_snow_amount_over_land">
+      <standard_name name="surface_snow_mass_content_over_land">
          <type kind="kind_phys" units="kg m-2">real</type>
       </standard_name>
       <standard_name name="upper_bound_of_max_albedo_assuming_deep_snow"
@@ -3686,7 +3688,7 @@ GFS near-surface sea temperature scheme
                    description="Volume fraction of unfrozen soil moisture for land surface model">
          <type kind="kind_phys" units="fraction">real</type>
       </standard_name>
-      <standard_name name="lwe_thickness_of_surface_snow_amount"
+      <standard_name name="lwe_thickness_of_surface_snow"
                    description="Liquid water equivalent thickness of surface snow amount">
          <type kind="kind_phys" units="mm">real</type>
       </standard_name>
@@ -3868,15 +3870,15 @@ GFS near-surface sea temperature scheme
       <standard_name name="y_wind_at_10m_for_coupling">
          <type kind="kind_phys" units="m s-1">real</type>
       </standard_name>
-      <standard_name name="cumulative_lwe_thickness_of_convective_precipitation_amount_for_coupling"
+      <standard_name name="cumulative_lwe_thickness_of_convective_precipitation_for_coupling"
                    description="Cumulative liquid water equivalent thickness of convective precipitation amount for coupling">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="cumulative_lwe_thickness_of_precipitation_amount_for_coupling"
+      <standard_name name="cumulative_lwe_thickness_of_precipitation_for_coupling"
                    description="Cumulative liquid water equivalent thickness of precipitation amount for coupling">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>
-      <standard_name name="cumulative_lwe_thickness_of_snow_amount_for_coupling"
+      <standard_name name="cumulative_lwe_thickness_of_snow_for_coupling"
                    description="Cumulative liquid water equivalent thickness of snow amount for coupling">
          <type kind="kind_phys" units="m">real</type>
       </standard_name>

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -576,7 +576,7 @@
               description="Density of dry air at standard temperature and pressure">
       <type units="kg m-3">real</type>
     </standard_name>
-    <standard_name name="fresh_liquid_water_density_at_0c"
+    <standard_name name="density_of_fresh_liquid_water_at_0c"
                    description="Density of liquid water at 0 degrees Celsius">
       <type units="kg m-3">real</type>
     </standard_name>
@@ -699,7 +699,7 @@
                    description="Dry static energy content of atmosphere layer">
       <type units="J kg-1">real</type>
     </standard_name>
-    <standard_name name="flag_for_lagrangian_vertical_coordinate"
+    <standard_name name="do_lagrangian_vertical_coordinate"
                    description="Flag indicating if vertical coordinate is lagrangian">
       <type units="flag">logical</type>
     </standard_name>

--- a/standard_names_v1_0.xsd
+++ b/standard_names_v1_0.xsd
@@ -32,7 +32,6 @@
 
   <xs:attribute name="comment"        type="xs:string"/>
   <xs:attribute name="description"      type="xs:string"/>
-  <xs:attribute name="kind"           type="xs:string"/>
   <xs:attribute name="name"           type="standard_name_type"/>
   <xs:attribute name="units"          type="xs:string"/>
   <xs:attribute name="version"        type="version_type"/>
@@ -42,7 +41,6 @@
   <xs:complexType name="md_type">
     <xs:simpleContent>
       <xs:extension base="type_type">
-        <xs:attribute ref="kind"  use="optional"/>
         <xs:attribute ref="units" use="required"/>
       </xs:extension>
     </xs:simpleContent>


### PR DESCRIPTION
## Description
This PR addresses the following issues:
 -  #94 Include more information on the role of "units"
 - #102 Remove "kind" from standard name entries 
 - Partially addresses #105: this PR removes the ambiguous term `amount` replacing it with more specific terms where needed, and includes a new section on "disallowed terms" that includes `specific_humidity` and `amount`.

In addition, this PR organizes the "constants" section alphabetically, and replaces the too-specific `dry_air_density` base name with `dry_air`, and change `dry_air_density` to `density_of_dry_air` to better fit with naming conventions in the updated rules.

## Issues
 - Resolves #94
 - Resolves #102 

