### PR TITLE
Adding standard names for chemical number densities, new rules about naming chemical species

### DIFF
--- a/Metadata-standard-names.md
+++ b/Metadata-standard-names.md
@@ -407,6 +407,46 @@ Note that appending '_on_previous_timestep' to standard_names in this section yi
     * `real(kind=kind_phys)`: units = mol mol-1
 * `volume_mixing_ratio_of_so2`: Sulfur dioxide volume mixing ratio
     * `real(kind=kind_phys)`: units = mol mol-1
+* `number_density_of_n`: Number density of neutral atomic nitrogen (N) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_n_from_climatology`: Climatological number density of atomic nitrogen (N), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_n2`: Number density of molecular nitrogen (N2) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_n2_from_climatology`: Climatological number density molecular nitrogen (N2), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_o`: Number density of neutral atomic oxygen (O) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_o_from_climatology`: Climatological number density of atomic oxygen (O), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_o2`: Number density of molecular oxygen (O2) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_o2_from_climatology`: Climatological number density molecular oxygen (O2), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_no`: Number density of nitric oxide (NO) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_no_from_climatology`: Climatological number density of nitric oxide (NO), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_ar`: Number density of argon (Ar) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_ar_from_climatology`: Climatological number density of argon (Ar), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_he`: Number density of helium (He) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_he_from_climatology`: Climatological number density of helium (He), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_h`: Number density of neutral atomic hydrogen (H) in air
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_h_from_climatology`: Climatological number density of atomic hydrogen (H), e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_anomalous_oxygen`: Number density of energetic, non-thermal atomic oxygen as defined in MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_anomalous_oxygen_from_climatology`: Climatological number density of anomalous energetic oxygen, e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_neutral_air`: Total number density of neutral air, including all neutral constituents
+    * `real(kind=kind_phys)`: units = m-3
+* `number_density_of_neutral_air_from_climatology`: Climatological total number density of neutral air, e.g., from MSIS
+    * `real(kind=kind_phys)`: units = m-3
 ## atmospheric_composition: GOCART aerosols
 * `mass_fraction_of_dust001_in_air`: Dust bin1 mass fraction
     * `real(kind=kind_phys)`: units = kg kg-1

--- a/Metadata-standard-names.yaml
+++ b/Metadata-standard-names.yaml
@@ -950,6 +950,108 @@ sections:
     type: real
     kind: kind_phys
     units: mol mol-1
+  - name: number_density_of_n
+    long_name: Number density of neutral atomic nitrogen (N) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_n_from_climatology
+    long_name: Climatological number density of atomic nitrogen (N), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_n2
+    long_name: Number density of molecular nitrogen (N2) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_n2_from_climatology
+    long_name: Climatological number density molecular nitrogen (N2), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_o
+    long_name: Number density of neutral atomic oxygen (O) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_o_from_climatology
+    long_name: Climatological number density of atomic oxygen (O), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_o2
+    long_name: Number density of molecular oxygen (O2) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_o2_from_climatology
+    long_name: Climatological number density molecular oxygen (O2), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_no
+    long_name: Number density of nitric oxide (NO) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_no_from_climatology
+    long_name: Climatological number density of nitric oxide (NO), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_ar
+    long_name: Number density of argon (Ar) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_ar_from_climatology
+    long_name: Climatological number density of argon (Ar), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_he
+    long_name: Number density of helium (He) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_he_from_climatology
+    long_name: Climatological number density of helium (He), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_h
+    long_name: Number density of neutral atomic hydrogen (H) in air
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_h_from_climatology
+    long_name: Climatological number density of atomic hydrogen (H), e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_anomalous_oxygen
+    long_name: Number density of energetic, non-thermal atomic oxygen as defined in
+      MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_anomalous_oxygen_from_climatology
+    long_name: Climatological number density of anomalous energetic oxygen, e.g.,
+      from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_neutral_air
+    long_name: Total number density of neutral air, including all neutral constituents
+    type: real
+    kind: kind_phys
+    units: m-3
+  - name: number_density_of_neutral_air_from_climatology
+    long_name: Climatological total number density of neutral air, e.g., from MSIS
+    type: real
+    kind: kind_phys
+    units: m-3
 - name: 'atmospheric_composition: GOCART aerosols'
   comment: null
   standard_names:

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -125,16 +125,17 @@ ESM Standard Name Rules
    aliases is below. Whenever such an alias exist, use the alias in the
    standard name and the full term in the long name.
 
-#. Chemical species in standard names should be denoted by chemical formulae (e.g. co2, ch4, c5h8)
-   or commonly accepted designations (e.g. cfc12); generally shorter names are preferred. A few
-   very common species with well-established and unambiguous standard names (e.g. water, ozone)
-   are also included. In all cases, the long name should include specific details about the
-   substance's chemical makeup, as well as the phase/state of matter if relevant.
+#. Chemical species in standard names should be denoted by chemical formulae (e.g. ``co2``,
+   ``ch4``, ``c5h8``) or commonly accepted designations (e.g. ``cfc12``); generally when there are
+   multiple options the shorter name is preferred. A few species with well-established and
+   unambiguous common names (e.g. water, ozone) are also included. In all cases, the long name
+   should include specific details about the substance's chemical makeup, as well as the
+   phase/state of matter if relevant; e.g. ``water_vapor``, ``liquid_h2so4``
 
-#. If the ionization of the chemical species is relevant, it should be included in the standard
-   name as a prefix to the substance; e.g. number_density_of_ionized_he for ionized helium. If
+#. If the ionization of the chemical species is relevant, "ionized" should be included in the standard
+   name as a prefix to the substance; e.g. ``number_density_of_ionized_he`` for ionized helium. If
    relevant, the net ionization charge should be included as a suffix (in words, because +/- are
-   not valid standard name characters); e.g. number_density_of_ionized_he_plus_1
+   not valid standard name characters); e.g. ``number_density_of_ionized_he_plus_1``
 
 #. For control-oriented variables, if the variable is a Fortran logical,
    use flag_for ``_X``. If it is any other data type, use control_for ``_X``. All flags

--- a/StandardNamesRules.rst
+++ b/StandardNamesRules.rst
@@ -125,6 +125,17 @@ ESM Standard Name Rules
    aliases is below. Whenever such an alias exist, use the alias in the
    standard name and the full term in the long name.
 
+#. Chemical species in standard names should be denoted by chemical formulae (e.g. co2, ch4, c5h8)
+   or commonly accepted designations (e.g. cfc12); generally shorter names are preferred. A few
+   very common species with well-established and unambiguous standard names (e.g. water, ozone)
+   are also included. In all cases, the long name should include specific details about the
+   substance's chemical makeup, as well as the phase/state of matter if relevant.
+
+#. If the ionization of the chemical species is relevant, it should be included in the standard
+   name as a prefix to the substance; e.g. number_density_of_ionized_he for ionized helium. If
+   relevant, the net ionization charge should be included as a suffix (in words, because +/- are
+   not valid standard name characters); e.g. number_density_of_ionized_he_plus_1
+
 #. For control-oriented variables, if the variable is a Fortran logical,
    use flag_for ``_X``. If it is any other data type, use control_for ``_X``. All flags
    should be Fortran logicals.

--- a/standard_names.xml
+++ b/standard_names.xml
@@ -700,6 +700,86 @@
                    long_name="Sulfur dioxide volume mixing ratio">
       <type kind="kind_phys" units="mol mol-1">real</type>
     </standard_name>
+    <standard_name name="number_density_of_n"
+                   long_name="Number density of neutral atomic nitrogen (N) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_n_from_climatology"
+                   long_name="Climatological number density of atomic nitrogen (N), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_n2"
+                   long_name="Number density of molecular nitrogen (N2) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_n2_from_climatology"
+                   long_name="Climatological number density molecular nitrogen (N2), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_o"
+                   long_name="Number density of neutral atomic oxygen (O) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_o_from_climatology"
+                   long_name="Climatological number density of atomic oxygen (O), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_o2"
+                   long_name="Number density of molecular oxygen (O2) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_o2_from_climatology"
+                   long_name="Climatological number density molecular oxygen (O2), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_no"
+                   long_name="Number density of nitric oxide (NO) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_no_from_climatology"
+                   long_name="Climatological number density of nitric oxide (NO), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_ar"
+                   long_name="Number density of argon (Ar) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_ar_from_climatology"
+                   long_name="Climatological number density of argon (Ar), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_he"
+                   long_name="Number density of helium (He) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_he_from_climatology"
+                   long_name="Climatological number density of helium (He), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_h"
+                   long_name="Number density of neutral atomic hydrogen (H) in air">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_h_from_climatology"
+                   long_name="Climatological number density of atomic hydrogen (H), e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_anomalous_oxygen"
+                   long_name="Number density of energetic, non-thermal atomic oxygen as defined in MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_anomalous_oxygen_from_climatology"
+                   long_name="Climatological number density of anomalous energetic oxygen, e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_neutral_air"
+                   long_name="Total number density of neutral air, including all neutral constituents">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
+    <standard_name name="number_density_of_neutral_air_from_climatology"
+                   long_name="Climatological total number density of neutral air, e.g., from MSIS">
+      <type kind="kind_phys" units="m-3">real</type>
+    </standard_name>
   </section>
     <section name="atmospheric_composition: GOCART aerosols">
     <standard_name name="mass_fraction_of_dust001_in_air"


### PR DESCRIPTION
## Description
This PR adds standard names for the number density of specific chemicals and their climatological values. These names are derived from discussion on Issue #112.

This also includes new rules regarding the naming of chemical species in standard names. These are my attempt at a draft of these rules and I welcome any feedback, corrections, or suggested changes, especially from anyone with more knowledge of atmospheric/geochemistry.

## Issues
Resolves #112 


